### PR TITLE
add Amazon os to package map

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -19,3 +19,7 @@ salt:
       test.baz:
         spam: sausage
         cheese: bread
+  package_table:
+    MyDistro:
+      salt-master: my-distro-salt-master
+      salt-minion: my-distro-salt-minion

--- a/salt/package-map.jinja
+++ b/salt/package-map.jinja
@@ -17,8 +17,4 @@
                'salt-minion':  'salt'}
 } %}
 
-{% if 'package_table' in pillar %}
-    {% set pkgs = pillar['package_table'] %}
-{% elif grains['os'] in package_table %}
-    {% set pkgs = package_table[grains['os']] %}
-{% endif %}
+{% set pkgs = salt['pillar.get']("salt:package_table:%s" % grains['os'], package_table[grains['os']]) %}


### PR DESCRIPTION
Amazon Linux is much like CentOS, but identifies itself as Amazon
