### PR TITLE
Namespace Pillar Package Table

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -19,3 +19,7 @@ salt:
       test.baz:
         spam: sausage
         cheese: bread
+  package_table:
+    MyDistro:
+      salt-master: my-distro-salt-master
+      salt-minion: my-distro-salt-minion

--- a/salt/package-map.jinja
+++ b/salt/package-map.jinja
@@ -15,8 +15,4 @@
                'salt-minion':  'salt'}
 } %}
 
-{% if 'package_table' in pillar %}
-    {% set pkgs = pillar['package_table'] %}
-{% elif grains['os'] in package_table %}
-    {% set pkgs = package_table[grains['os']] %}
-{% endif %}
+{% set pkgs = salt['pillar.get']("salt:package_table:%s" % grains['os'], package_table[grains['os']]) %}


### PR DESCRIPTION
It seems wrong to me that a formula specific package_table should be in the pillar root level.  This pull request moves it to live with the rest of the pillar data expected by the formula in pillar['salt'].  Additionally, I removed the if/elif statement in favor of pillar.get,  this will provide simple fallback to the hardcoded package_table if the os doesn't exist in the pillar package_table.