### PR TITLE
add Amazon os to package map

### DIFF
--- a/salt/package-map.jinja
+++ b/salt/package-map.jinja
@@ -5,6 +5,8 @@
                'salt-minion': 'salt-minion'},
     'CentOS': {'salt-master': 'salt-master',
                'salt-minion': 'salt-minion'},
+    'Amazon': {'salt-master': 'salt-master',
+               'salt-minion': 'salt-minion'},
     'Fedora': {'salt-master': 'salt-master',
                'salt-minion': 'salt-minion'},
     'RedHat': {'salt-master': 'salt-master',


### PR DESCRIPTION
Amazon Linux is much like CentOS, but identifies itself as Amazon

resubmit of pull request https://github.com/saltstack-formulas/salt-formula/pull/29 from the correct branch this time
