### PR TITLE
log_granular_levels pillar data looks at the wrong thing

### DIFF
--- a/salt/files/master
+++ b/salt/files/master
@@ -728,7 +728,7 @@ peer_run:
 #
 {% if 'log_granular_levels' in master %}
 log_granular_levels:
-  {% for name, lvl in salt['log_granular_levels'] %}
+  {% for name, lvl in master['log_granular_levels'] %}
   {{ name }}: {{ lvl }}
   {% endfor -%}
 {% elif 'log_granular_levels' in salt %}


### PR DESCRIPTION
if you set log_granular_levels in the master section of pillar data, the template will try to use the salt section
