### PR TITLE
Fixed typo in autoreject_file setting

### DIFF
--- a/salt/files/master
+++ b/salt/files/master
@@ -157,7 +157,7 @@
 # Works like autosign_file, but instead allows you to specify minion IDs for
 # which keys will automatically be rejected. Will override both membership in
 # the autosign_file and the auto_accept setting.
-{{ get_config('autorejecte_file', '/etc/salt/autosign.conf') }}
+{{ get_config('autoreject_file', '/etc/salt/autosign.conf') }}
 
 # Enable permissive access to the salt keys.  This allows you to run the
 # master or minion as root, but have a non-root group be given access to


### PR DESCRIPTION
Fixed an apparent typo in the autoreject_file setting (which was listed as autorejecte_file, see http://docs.saltstack.com/en/latest/ref/configuration/master.html#std:conf_master-autoreject_file)
