### PR TITLE
Removed crypto dependency from salt.cloud.

### DIFF
--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -10,11 +10,6 @@ pycrypto:
     - require:
       - pkg: python-pip
 
-crypto:
-  pip.installed:
-    - require:
-      - pkg: python-pip
-
 apache-libcloud:
   pip.installed:
     - require:
@@ -26,7 +21,6 @@ salt-cloud:
     - require:
       - pip: apache-libcloud
       - pip: pycrypto
-      - pip: crypto
 
 {% for folder in cloud['folders'] %}
 {{ folder }}:


### PR DESCRIPTION
The crypto package isn't available from pip anymore, and salt-cloud 
seems to work fine without it. See issue #59.

I don't know much about salt-cloud's internals, so it's possible the
dependency is there for some reason I'm not aware of. Someone
more knowledgeable should probably review this first. 
