### PR TITLE
enables use of jinja < 2.6

### DIFF
--- a/salt/files/master.d/_defaults.conf
+++ b/salt/files/master.d/_defaults.conf
@@ -484,7 +484,7 @@ fileserver_backend:
 {% if 'gitfs_remotes' in master -%}
 gitfs_remotes:
 {%- for remote in master['gitfs_remotes'] %}
-{% if remote is mapping %}
+{% if remote is iterable %}
   {%- for repo, children in remote.iteritems() -%}
     - {{ repo }}:
   {%- for child in children %}


### PR DESCRIPTION
Commit 2b51a6f0c39b4df56823afe9d114dab886e3359e introduced options for gitfs_remotes in a pillar by using a jinja test to see if a parameter is a mapping (dict etc.). This feature however is only available in jinja 2.6 or newer (see http://jinja.pocoo.org/docs/dev/templates/#mapping).
Although this version of Jinja is available on Ubuntu, other OS / package managers do provide older versions (2.2.1 in RedHat 6).

This change makes use of the "iterable" test which should do the exact same thing.
