### PR TITLE
adds `yaml_utf8` option to master config

### DIFF
--- a/salt/files/master.d/_defaults.conf
+++ b/salt/files/master.d/_defaults.conf
@@ -321,6 +321,8 @@ client_acl_blacklist:
 # will be terse unless a state failed, in which case that output will be full.
 {{ get_config('state_output', 'full') }}
 
+{{ get_config('yaml_utf8', 'False')  }}
+
 
 #####      File Server settings      #####
 ##########################################


### PR DESCRIPTION
Reference about this config value: http://docs.saltstack.com/en/latest/ref/configuration/master.html#yaml-utf8
Reference why this might be useful: https://github.com/saltstack/salt/issues/3436#issuecomment-61225863
