### PR TITLE
Test if individual gitfs remote is string

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -4,7 +4,7 @@ salt:
       - git
       - roots
     gitfs_remotes:
-      - git://github.com/saltstack-formulas/salt-formula.git
+      - git://github.com/saltstack-formulas/salt-formula.git:
         - base: develop
     file_roots:
       base:

--- a/salt/files/master.d/_defaults.conf
+++ b/salt/files/master.d/_defaults.conf
@@ -486,7 +486,7 @@ fileserver_backend:
 {% if 'gitfs_remotes' in master -%}
 gitfs_remotes:
 {%- for remote in master['gitfs_remotes'] %}
-{% if remote is iterable %}
+{% if remote is iterable and remote is not string %}
   {%- for repo, children in remote.iteritems() -%}
     - {{ repo }}:
   {%- for child in children %}


### PR DESCRIPTION
Fixes issue https://github.com/saltstack-formulas/salt-formula/issues/64 where a gitfs remote that has no child options would cause an error. Also fix up bad yaml in pillar example.
