### PR TITLE
Added support for salt minion gitfs

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -11,6 +11,15 @@ salt:
         - /srv/salt
   minion:
     master: salt
+    fileserver_backend:
+      - git
+      - roots
+    gitfs_remotes:
+      - git://github.com/saltstack-formulas/salt-formula.git:
+        - base: develop
+    file_roots:
+      base:
+        - /srv/salt
     module_config:
       test: True
       test.foo: foo

--- a/salt/files/minion.d/_defaults.conf
+++ b/salt/files/minion.d/_defaults.conf
@@ -434,7 +434,57 @@ file_roots:
 # Default is False.
 #
 {{ get_config('fileserver_limit_traversal', 'False') }}
-
+#
+# Git fileserver backend configuration
+#
+# Gitfs can be provided by one of two python modules: GitPython or pygit2. If
+# using pygit2, both libgit2 and git must also be installed.
+{{ get_config('gitfs_provider', 'pygit2') }}
+#
+# When using the git fileserver backend at least one git remote needs to be
+# defined. The user running the salt master will need read access to the repo.
+#
+# The repos will be searched in order to find the file requested by a client
+# and the first repo to have the file will return it.
+# When using the git backend branches and tags are translated into salt
+# environments.
+# Note:  file:// repos will be treated as a remote, so refs you want used must
+# exist in that repo as *local* refs.
+{% if 'gitfs_remotes' in minion -%}
+gitfs_remotes:
+{%- for remote in minion['gitfs_remotes'] %}
+{% if remote is mapping %}
+  {%- for repo, children in remote.iteritems() -%}
+    - {{ repo }}:
+  {%- for child in children %}
+    {% for key, value in child.iteritems() -%}
+      - {{ key }}: {{ value }}
+    {%- endfor %}
+  {%- endfor %}
+  {%- endfor %}
+  {%- else -%}
+    - {{ remote }}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+#
+#gitfs_remotes:
+#  - git://github.com/saltstack/salt-states.git
+#  - file:///var/git/saltmaster
+#
+# The gitfs_ssl_verify option specifies whether to ignore ssl certificate
+# errors when contacting the gitfs backend. You might want to set this to
+# false if you're using a git backend that uses a self-signed certificate but
+# keep in mind that setting this flag to anything other than the default of True
+# is a security concern, you may want to try using the ssh transport.
+{{ get_config('gitfs_ssl_verify', 'True') }}
+#
+#
+# The gitfs_root option gives the ability to serve files from a subdirectory
+# within the repository. The path is defined relative to the root of the
+# repository and defaults to the repository root.
+{{ get_config('gitfs_root', 'somefolder/otherfolder') }}
+#
 # The hash_type is the hash to use when discovering the hash of a file in
 # the local fileserver. The default is md5, but sha1, sha224, sha256, sha384
 # and sha512 are also supported.


### PR DESCRIPTION
Gitfs for the minion is possible with salt 2014.7
Updated config _defaults.conf and pillar with example
Tested it on Archlinux with salt-call --local state.highstate
