### PR TITLE
Fix link and title in salt.standalone section of README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,10 +42,10 @@ Install salt-ssh with roster file.
 Configure pillar data under salt:ssh_roster to feed the template.
 
 ``salt.standalone``
-------------
+-------------------
 
 Install a minion and configure it in `standalone mode
-<docs.saltstack.com/en/latest/topics/tutorials/standalone_minion.html>`_.
+<http://docs.saltstack.com/en/latest/topics/tutorials/standalone_minion.html>`_.
 
 ``Configuration``
 =================


### PR DESCRIPTION
Fixes small details missed in b93ec22244e28f35fc5b430943e6b38666891d5d which got merged in pull request #73.
