### PR TITLE
FIxes for nodegroups/log_granular_levels settings and small cleanups

### DIFF
--- a/salt/files/master.d/_defaults.conf
+++ b/salt/files/master.d/_defaults.conf
@@ -613,10 +613,10 @@ fileserver_backend:
 gitfs_remotes:
 {%- for remote in master['gitfs_remotes'] %}
 {%- if remote is iterable and remote is not string %}
-  {%- for repo, children in remote.iteritems() %}
+  {%- for repo, children in remote.items() %}
     - {{ repo }}:
   {%- for child in children %}
-    {%- for key, value in child.iteritems() %}
+    {%- for key, value in child.items() %}
       - {{ key }}: {{ value }}
     {%- endfor -%}
   {%- endfor -%}
@@ -942,7 +942,7 @@ win_gitrepos:
 #####             Halite             #####
 ##########################################
 halite:
-  {% for name, value in master['halite'].iteritems() %}
+  {% for name, value in master['halite'].items() %}
   {{ name }}: {{ value }}
   {% endfor %}
 {% endif %}
@@ -951,7 +951,7 @@ halite:
 #####         rest_cherrypy          #####
 ##########################################
 rest_cherrypy:
-  {% for name, value in master['rest_cherrypy'].iteritems() %}
+  {% for name, value in master['rest_cherrypy'].items() %}
   {{ name }}: {{ value }}
   {% endfor %}
 {% endif %}

--- a/salt/files/minion.d/_defaults.conf
+++ b/salt/files/minion.d/_defaults.conf
@@ -458,10 +458,10 @@ file_roots:
 gitfs_remotes:
 {%- for remote in minion['gitfs_remotes'] %}
 {%- if remote is iterable and remote is not string %}
-  {%- for repo, children in remote.iteritems() %}
+  {%- for repo, children in remote.items() %}
     - {{ repo }}:
   {%- for child in children %}
-    {%- for key, value in child.iteritems() %}
+    {%- for key, value in child.items() %}
       - {{ key }}: {{ value }}
     {%- endfor -%}
   {%- endfor -%}


### PR DESCRIPTION
The first commit is a bugfix concerning the way we handle the nodegroups/log_granular_levels settings. The second commit is just a small cleanup for better Python 3 compatibility (and for consistency since both methods were already in use in this formula).
