### PR TITLE
Add saltify provider, map and profile templates

### DIFF
--- a/salt/files/cloud.maps.d/saltify.conf
+++ b/salt/files/cloud.maps.d/saltify.conf
@@ -1,0 +1,7 @@
+# This file is managed by Salt via {{ source }}
+make_salty:
+  - someinstance:
+      ssh_host: somehost.somedomain
+      ssh_username: user
+      password: password
+      sudo: True

--- a/salt/files/cloud.profiles.d/saltify.conf
+++ b/salt/files/cloud.profiles.d/saltify.conf
@@ -1,0 +1,3 @@
+# This file is managed by Salt via {{ source }}
+make_salty:
+  provider: saltify

--- a/salt/files/cloud.providers.d/saltify.conf
+++ b/salt/files/cloud.providers.d/saltify.conf
@@ -1,0 +1,3 @@
+# This file is managed by Salt via {{ source }}
+saltify:
+  provider: saltify


### PR DESCRIPTION
This makes it a little easier to bootstrap virgin machine that does not have salt installed.

I found it tricky to to follow the docs at http://docs.saltstack.com/en/latest/topics/cloud/config.html#saltify

If someone provides a better concrete example on how to saltify a fresh machine in this formula then please do so.
