### PR TITLE
Updated map.jinja for archlinux package convention

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,14 @@
 salt:
+
+  # to overwrite map.jinja salt packages
+  lookup:
+    salt-master: 'salt-master'
+    salt-minion: 'salt-minion'
+    salt-syndic: 'salt-syndic'
+    salt-cloud: 'salt-cloud'
+    salt-ssh: 'salt-ssh'
+
+  # salt master config
   master:
     fileserver_backend:
       - git
@@ -9,6 +19,8 @@ salt:
     file_roots:
       base:
         - /srv/salt
+ 
+  # salt minion config:
   minion:
     master: salt
     fileserver_backend:
@@ -29,6 +41,8 @@ salt:
       test.baz:
         spam: sausage
         cheese: bread
+
+  # salt cloud config
   cloud:
     master: salt
     folders:

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -1,4 +1,4 @@
-{% set map = {
+{% set salt = salt['grains.filter_by']({
     'Debian':  {'salt-master': 'salt-master',
                 'salt-minion': 'salt-minion',
                 'salt-syndic': 'salt-syndic',
@@ -33,11 +33,11 @@
                 'salt-minion': 'app-admin/salt',
                 'salt-syndic': 'app-admin/salt',
                 'salt-cloud': 'app-admin/salt'},
-    'Arch':    {'salt-master': 'salt',
-                'salt-minion':  'salt',
-                'salt-syndic':  'salt',
-                'salt-cloud':  'salt',
-                'salt-ssh':  'salt'},
+    'Arch':    {'salt-master': 'salt-zmq',
+                'salt-minion':  'salt-zmq',
+                'salt-syndic':  'salt-zmq',
+                'salt-cloud':  'salt-zmq',
+                'salt-ssh':  'salt-zmq'},
     'openSUSE':{'salt-master': 'salt-master',
                 'salt-minion':  'salt-minion',
                 'salt-syndic':  'salt-syndic',
@@ -51,10 +51,4 @@
                 'minion-service': 'salt_minion',
                 'master-service': 'salt_master',
                 'syndic-service': 'salt_syndic'},
-} %}
-
-{% if grains.get('saltversion', '').startswith('0.17') %}
-{% set salt= salt['grains.filter_by'](map, merge=salt['pillar.get']('salt:lookup'), base='default') %}
-{% else %}
-{% set salt = map.get(grains.os_family) %}
-{% endif %}
+}, merge=salt['pillar.get']('salt:lookup')) %}


### PR DESCRIPTION
Archlinux has salt-raet or salt-zmq in repository, I have choosen salt-zmq as default in map.jinja

Improved the override function without the base='default' parameter, so to be backward compatible to 0.17 salt version see pillar.example for lookup function override.