### PR TITLE
don't try to load pkgrepo on non-Debian distros

### DIFF
--- a/salt/pkgrepo/init.sls
+++ b/salt/pkgrepo/init.sls
@@ -1,2 +1,4 @@
+{% if grains['os_family'] == 'Debian' %}
 include:
   - .{{ grains['os']|lower }}
+{% endif %}


### PR DESCRIPTION
fixes #83 by wrapping contents of pkgrepo/init.sls in an {% if %}.

Change-Id: I8260fdf5cf802c0b28197516da374add6c3002a2