### PR TITLE
create config option for mine_interval

### DIFF
--- a/salt/files/minion.d/_defaults.conf
+++ b/salt/files/minion.d/_defaults.conf
@@ -181,6 +181,10 @@ id: {{ cfg_minion['id'] }}
 # Ping Master to ensure connection is alive (minutes).
 {{ get_config('ping_interval', '0') }}
 
+# The Salt Mine functions are executed when the minion starts and at a given interval by the scheduler.
+# The default interval is every 60 minutes.
+{{ get_config('mine_interval', '60') }}
+
 # To auto recover minions if master changes IP address (DDNS)
 #    auth_tries: 10
 #    auth_safemode: False


### PR DESCRIPTION
Make the mine_interval time configurable with the salt-formula.
only option from the mine_functions that cannot be set with pillar data

see:
http://docs.saltstack.com/en/latest/topics/mine/#mine-interval
