### PR TITLE
Stop using clean: True on /etc/salt/{minion,master}.d

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,5 @@
 salt:
+  clean_config_d_dir: False
 
   # to overwrite map.jinja salt packages
   lookup:
@@ -27,18 +28,18 @@ salt:
       ssl_key: /etc/pki/api/certs/server.key
       debug: False
       disable_ssl: False
- 
+
   # salt minion config:
   minion:
 
     # single master setup
     master: salt
-    
+
     # multi master setup
     master:
       - salt_master_1
       - salt_master_2
-    
+
     fileserver_backend:
       - git
       - roots

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,7 @@
 salt:
+  # Set this to true to clean any non-salt-formula managed files out of
+  # /etc/salt/{master,minion}.d ... You really don't want to do this on 2015.2
+  # and up as it'll wipe out important files that Salt relies on.
   clean_config_d_dir: False
 
   # to overwrite map.jinja salt packages

--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -10,3 +10,4 @@ salt:
   salt_cloud: salt-cloud
   salt_api: salt-api
   salt_ssh: salt-ssh
+  clean_config_d_dir: False

--- a/salt/master.sls
+++ b/salt/master.sls
@@ -7,7 +7,7 @@ salt-master:
     - name: {{ salt_settings.config_path }}/master.d
     - template: jinja
     - source: salt://salt/files/master.d
-    - clean: True
+    - clean: {{ salt_settings.clean_config_d_dir }}
   service.running:
     - enable: True
     - name: {{ salt_settings.master_service }}

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -7,7 +7,7 @@ salt-minion:
     - name: {{ salt_settings.config_path }}/minion.d
     - template: jinja
     - source: salt://salt/files/minion.d
-    - clean: True
+    - clean: {{ salt_settings.clean_config_d_dir }}
     - context:
         standalone: False
   service.running:

--- a/salt/standalone.sls
+++ b/salt/standalone.sls
@@ -7,7 +7,7 @@ salt-minion:
     - name: {{ salt_settings.config_path }}/minion.d
     - template: jinja
     - source: salt://salt/files/minion.d
-    - clean: True
+    - clean: {{ salt_settings.clean_config_d_dir }}
     - context:
         standalone: True
   service.dead:


### PR DESCRIPTION
New versions of Salt put config files in /etc/salt/{minion,master}.d. We don't
want to erase them by using a clean: True on the file.recurse. This is a
backward incompatible change, but it's necessary to avoid deleting Salt config
files.