### PR TITLE
Add setting to not install packages

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -4,6 +4,10 @@ salt:
   # and up as it'll wipe out important files that Salt relies on.
   clean_config_d_dir: False
 
+  # Set this to False to not have the formula install packages (in the case you
+  # install Salt via git/pip/etc.)
+  install_packages: True
+
   # to overwrite map.jinja salt packages
   lookup:
     salt-master: 'salt-master'

--- a/salt/api.sls
+++ b/salt/api.sls
@@ -4,8 +4,10 @@ include:
   - salt.master
 
 salt-api:
+{% if salt_settings.install_packages %}
   pkg.installed:
     - name: {{ salt_settings.salt_api }}
+{% endif %}
   service.running:
     - name: {{ salt_settings.api_service }}
     - require:

--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -20,6 +20,7 @@ apache-libcloud:
     - require:
       - pkg: python-pip
 
+{% if salt_settings.install_packages %}
 salt-cloud:
   pkg.installed:
     - name: {{ salt_settings.salt_cloud }}
@@ -29,6 +30,7 @@ salt-cloud:
       {% if grains['os_family'] not in ['Debian', 'RedHat'] %}
       - pip: crypto
       {% endif %}
+{% endif %}
 
 {% for folder in salt_settings.cloud.folders %}
 {{ folder }}:

--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -1,4 +1,5 @@
 salt:
+  install_packages: True
   config_path: /etc/salt
   minion_service: salt-minion
   master_service: salt-master

--- a/salt/master.sls
+++ b/salt/master.sls
@@ -1,8 +1,10 @@
 {% from "salt/map.jinja" import salt_settings with context %}
 
 salt-master:
+{% if salt_settings.install_packages %}
   pkg.installed:
     - name: {{ salt_settings.salt_master }}
+{% endif %}
   file.recurse:
     - name: {{ salt_settings.config_path }}/master.d
     - template: jinja
@@ -12,5 +14,7 @@ salt-master:
     - enable: True
     - name: {{ salt_settings.master_service }}
     - watch:
+{% if salt_settings.install_packages %}
       - pkg: salt-master
+{% endif %}
       - file: salt-master

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -1,8 +1,10 @@
 {% from "salt/map.jinja" import salt_settings with context %}
 
 salt-minion:
+{% if salt_settings.install_packages %}
   pkg.installed:
     - name: {{ salt_settings.salt_minion }}
+{% endif %}
   file.recurse:
     - name: {{ salt_settings.config_path }}/minion.d
     - template: jinja
@@ -14,5 +16,7 @@ salt-minion:
     - enable: True
     - name: {{ salt_settings.minion_service }}
     - watch:
+{% if salt_settings.install_packages %}
       - pkg: salt-minion
+{% endif %}
       - file: salt-minion

--- a/salt/ssh.sls
+++ b/salt/ssh.sls
@@ -1,8 +1,10 @@
 {% from "salt/map.jinja" import salt_settings with context %}
 
+{% if salt_settings.install_packages %}
 ensure salt-ssh is installed:
   pkg.installed:
     - name: {{ salt_settings.salt_ssh }}
+{% endif %}
 
 ensure roster config:
   file.managed:
@@ -10,4 +12,6 @@ ensure roster config:
     - source: salt://salt/files/roster.jinja
     - template: jinja
     - require:
+{% if salt_settings.install_packages %}
       - pkg: ensure salt-ssh is installed
+{% endif %}

--- a/salt/standalone.sls
+++ b/salt/standalone.sls
@@ -1,8 +1,10 @@
 {% from "salt/map.jinja" import salt_settings with context %}
 
 salt-minion:
+{% if salt_settings.install_packages %}
   pkg.installed:
     - name: {{ salt_settings.salt_minion }}
+{% endif %}
   file.recurse:
     - name: {{ salt_settings.config_path }}/minion.d
     - template: jinja
@@ -14,5 +16,7 @@ salt-minion:
     - enable: False
     - name: {{ salt_settings.minion_service }}
     - require:
+{% if salt_settings.install_packages %}
       - pkg: salt-minion
+{% endif %}
       - file: salt-minion

--- a/salt/syndic.sls
+++ b/salt/syndic.sls
@@ -4,12 +4,16 @@ include:
   - salt.master
 
 salt-syndic:
+{% if salt_settings.install_packages %}
   pkg.installed:
     - name: {{ salt_settings.salt_syndic }}
+{% endif %}
   service:
     - running
     - require:
       - service: {{ salt_settings.syndic_service }}
     - watch:
+{% if salt_settings.install_packages %}
       - pkg: salt-master
+{% endif %}
       - file: {{ salt_settings.config_path }}/master


### PR DESCRIPTION
If you are installing Salt via git/pip, the formula will try to overwrite your
install with packaged versions. This setting makes it possible to avoid that.