### PR TITLE
[bugfix] Reverts lookup of salt_cloud_certs to original pillar key, in line with ...

### DIFF
--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -43,7 +43,7 @@ salt-cloud:
     - makedirs: True
 {% endfor %}
 
-{% for cert in salt_settings.salt_cloud_certs %}
+{% for cert in pillar.get('salt_cloud_certs', {}) %}
 {% for type in ['pem'] %}
 cloud-cert-{{ cert }}-pem:
   file.managed:


### PR DESCRIPTION
...existing documentation and the certificate template file.

This fixes issue https://github.com/saltstack-formulas/salt-formula/issues/113.