### PR TITLE
Added mine_functions to f_defaults.conf.

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -66,6 +66,15 @@ salt:
         spam: sausage
         cheese: bread
 
+    # salt mine setup
+    mine_interval: 60
+    # mine_functions can be set at the top level of the pillar, and
+    # that is preferable because it doesn't affect the conf file and
+    # doesn't require a minion restart. However, you can configure it
+    # here instead if you really want to.
+    mine_functions:
+      network.interface_ip: [eth0]
+
   # salt cloud config
   cloud:
     master: salt

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -185,6 +185,13 @@ id: {{ cfg_minion['id'] }}
 # The default interval is every 60 minutes.
 {{ get_config('mine_interval', '60') }}
 
+{%- if 'mine_functions' in cfg_minion %}
+mine_functions:
+{%- for func, args in cfg_minion['mine_functions'].items() %}
+  {{ func }}: {{ args }}
+{%- endfor %}
+{%- endif %}
+
 # To auto recover minions if master changes IP address (DDNS)
 #    auth_tries: 10
 #    auth_safemode: False


### PR DESCRIPTION
I'm not sure why mine_interval is included in the conf file but mine_functions isn't. Up till now I've been adding a separate file to manage it in my own installation, but this seems like something the formula should support. 