### PR TITLE
Added pillar option to redirect profile and map folders.

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -82,9 +82,9 @@ salt:
     # You can take profile and map templates from an alternate location
     # if you want to write your own.
     template_sources:
-      providers: salt://templates/cloud.providers.d
-      profiles: salt://templates/cloud.profiles.d
-      maps: salt://templates/cloud.maps.d
+      providers: salt://salt/files/cloud.providers.d
+      profiles: salt://salt/files/cloud.profiles.d
+      maps: salt://salt/files/cloud.maps.d
 
     # These settings are used by the default provider templates and
     # only need to be set for the ones you're using.

--- a/pillar.example
+++ b/pillar.example
@@ -78,19 +78,16 @@ salt:
   # salt cloud config
   cloud:
     master: salt
-    folders:
-      - cloud.providers.d/key
-      - cloud.profiles.d
-      - cloud.maps.d
 
     # You can take profile and map templates from an alternate location
-    # if desired.
-    profiles_src: salt://templates/cloud.profiles.d
-    maps_src: salt://templates/cloud.maps.d
+    # if you want to write your own.
+    template_sources:
+      providers: salt://templates/cloud.providers.d
+      profiles: salt://templates/cloud.profiles.d
+      maps: salt://templates/cloud.maps.d
 
-    providers:
-      - ec2
-      - gce
+    # These settings are used by the default provider templates and
+    # only need to be set for the ones you're using.
     aws_key: AWSKEYIJSHJAIJS6JSH
     aws_secret: AWSSECRETYkkDY1iQf9zRtl9+pW+Nm+aZY95
     gce_project: test

--- a/pillar.example
+++ b/pillar.example
@@ -82,6 +82,12 @@ salt:
       - cloud.providers.d/key
       - cloud.profiles.d
       - cloud.maps.d
+
+    # You can take profile and map templates from an alternate location
+    # if desired.
+    profiles_src: salt://templates/cloud.profiles.d
+    maps_src: salt://templates/cloud.maps.d
+
     providers:
       - ec2
       - gce

--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -49,12 +49,11 @@ cloud-cert-{{ cert }}-pem:
 {% endfor %}
 {% endfor %}
 
-{%- for dir in ['providers', 'profiles', 'maps'] %}
-{%- set source = salt_settings.cloud.template_sources.get(dir) %}
+{%- for dir, templ_path in salt_settings.cloud.template_sources.items() %}
 salt-cloud-{{ dir }}:
   file.recurse:
     - name: /etc/salt/cloud.{{ dir }}.d
-    - source: {{ source }}
+    - source: {{ templ_path }}
     - template: jinja
     - makedirs: True
 {%- endfor %}

--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -32,47 +32,33 @@ salt-cloud:
       {% endif %}
 {% endif %}
 
-{% for folder in salt_settings.cloud.folders %}
-{{ folder }}:
-  file.directory:
-    - name: /etc/salt/{{ folder }}
-    - user: root
-    - group: root
-    - file_mode: 744
-    - dir_mode: 755
-    - makedirs: True
-{% endfor %}
-
 {% for cert in pillar.get('salt_cloud_certs', {}) %}
 {% for type in ['pem'] %}
 cloud-cert-{{ cert }}-pem:
   file.managed:
-    - name: /etc/salt/cloud.providers.d/key/{{ cert }}.pem
+    - name: /etc/salt/pki/cloud/{{ cert }}.pem
     - source: salt://salt/files/key
     - template: jinja
     - user: root
     - group: root
     - mode: 600
+    - makedirs: True
     - defaults:
         key: {{ cert }}
         type: {{ type }}
 {% endfor %}
 {% endfor %}
 
-{% for providers in salt_settings.cloud.providers %}
-salt-cloud-providers-{{ providers }}:
-  file.managed:
-    - name: /etc/salt/cloud.providers.d/{{ providers }}.conf
-    - template: jinja
-    - source: salt://salt/files/cloud.providers.d/{{ providers }}.conf
-{% endfor %}
-
-{%- for dir in ['profiles', 'maps'] %}
-{%- set default_src = 'salt://salt/files/cloud.{}.d'.format(dir) %}
-{%- set source = salt_settings.cloud.get(dir + "_src", default_src) %}
+{%- for dir in ['providers', 'profiles', 'maps'] %}
+{%- set source = salt_settings.cloud.template_sources.get(dir) %}
 salt-cloud-{{ dir }}:
   file.recurse:
     - name: /etc/salt/cloud.{{ dir }}.d
     - source: {{ source }}
     - template: jinja
+    - user: root
+    - group: root
+    - dir_mode: 755
+    - file_mode: 644
+    - makedirs: True
 {%- endfor %}

--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -60,21 +60,19 @@ cloud-cert-{{ cert }}-pem:
 {% endfor %}
 
 {% for providers in salt_settings.cloud.providers %}
-salt-cloud-profiles-{{ providers }}:
-  file.managed:
-    - name: /etc/salt/cloud.profiles.d/{{ providers }}.conf
-    - template: jinja
-    - source: salt://salt/files/cloud.profiles.d/{{ providers }}.conf
-
 salt-cloud-providers-{{ providers }}:
   file.managed:
     - name: /etc/salt/cloud.providers.d/{{ providers }}.conf
     - template: jinja
     - source: salt://salt/files/cloud.providers.d/{{ providers }}.conf
-
-salt-cloud-maps-{{ providers }}:
-  file.managed:
-    - name: /etc/salt/cloud.maps.d/{{ providers }}.conf
-    - template: jinja
-    - source: salt://salt/files/cloud.maps.d/{{ providers }}.conf
 {% endfor %}
+
+{%- for dir in ['profiles', 'maps'] %}
+{%- set default_src = 'salt://salt/files/cloud.{}.d'.format(dir) %}
+{%- set source = salt_settings.cloud.get(dir + "_src", default_src) %}
+salt-cloud-{{ dir }}:
+  file.recurse:
+    - name: /etc/salt/cloud.{{ dir }}.d
+    - source: {{ source }}
+    - template: jinja
+{%- endfor %}

--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -56,9 +56,17 @@ salt-cloud-{{ dir }}:
     - name: /etc/salt/cloud.{{ dir }}.d
     - source: {{ source }}
     - template: jinja
-    - user: root
-    - group: root
-    - dir_mode: 755
-    - file_mode: 644
     - makedirs: True
 {%- endfor %}
+
+salt-cloud-providers-permissions:
+  file.directory:
+    - name: /etc/salt/cloud.providers.d
+    - user: root
+    - group: root
+    - file_mode: 600
+    - dir_mode: 700
+    - recurse:
+      - user
+      - group
+      - mode

--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -23,3 +23,9 @@ salt:
       install_from_source: True
     gitpython:
       install_from_source: False
+
+  cloud:
+    template_sources:
+      providers: salt://salt/files/cloud.providers.d
+      profiles: salt://salt/files/cloud.profiles.d
+      maps: salt://salt/files/cloud.maps.d

--- a/salt/files/cloud.providers.d/ec2.conf
+++ b/salt/files/cloud.providers.d/ec2.conf
@@ -8,7 +8,7 @@ ec2_ubuntu_public:
   ssh_interface: public_ips
   id: {{ cloud.get('aws_key', 'DEFAULT') }}
   key: '{{ cloud.get('aws_secret', 'DEFAULT') }}'
-  private_key: /etc/salt/cloud.providers.d/key/key.pem
+  private_key: /etc/salt/pki/cloud/ec2.pem
   keyname: keyname
   location: eu-west-1
   availability_zone: eu-west-1a

--- a/salt/files/cloud.providers.d/ec2.conf
+++ b/salt/files/cloud.providers.d/ec2.conf
@@ -2,12 +2,12 @@
 {% set cloud = salt['pillar.get']('salt:cloud', {}) -%}
 ec2_ubuntu_public:
   minion:
-    master: {{ cloud['master'] }}
+    master: {{ cloud.get('master', 'salt') }}
   grains:
     test: True
   ssh_interface: public_ips
-  id: {{ cloud['aws_key'] }}
-  key: '{{ cloud['aws_secret'] }}'
+  id: {{ cloud.get('aws_key', 'DEFAULT') }}
+  key: '{{ cloud.get('aws_secret', 'DEFAULT') }}'
   private_key: /etc/salt/cloud.providers.d/key/key.pem
   keyname: keyname
   location: eu-west-1

--- a/salt/files/cloud.providers.d/gce.conf
+++ b/salt/files/cloud.providers.d/gce.conf
@@ -1,11 +1,11 @@
 # This file managed by Salt, do not edit by hand!!
 {% set cloud = salt['pillar.get']('salt:cloud', {}) -%}
 gce:
-  project: "{{ cloud['gce_project'] }}"
-  service_account_email_address: "{{ cloud['gce_service_account_email_address'] }}"
+  project: "{{ cloud.get('gce_project', 'DEFAULT') }}"
+  service_account_email_address: "{{ cloud.get('gce_service_account_email_address', 'DEFAULT') }}"
   service_account_private_key: "/etc/salt/cloud.providers.d/key.pem"
   minion:
-    master: {{ cloud['master'] }}
+    master: {{ cloud.get('master', 'salt') }}
   grains:
     test: True
   provider: gce

--- a/salt/files/cloud.providers.d/gce.conf
+++ b/salt/files/cloud.providers.d/gce.conf
@@ -3,7 +3,7 @@
 gce:
   project: "{{ cloud.get('gce_project', 'DEFAULT') }}"
   service_account_email_address: "{{ cloud.get('gce_service_account_email_address', 'DEFAULT') }}"
-  service_account_private_key: "/etc/salt/cloud.providers.d/key.pem"
+  service_account_private_key: "/etc/salt/pki/cloud/gce.pem"
   minion:
     master: {{ cloud.get('master', 'salt') }}
   grains:

--- a/salt/files/cloud.providers.d/rsos.conf
+++ b/salt/files/cloud.providers.d/rsos.conf
@@ -6,7 +6,7 @@
 
 rsos_{{ region|lower }}:
   minion:
-    master: {{ cloud['master'] }}
+    master: {{ cloud.get('master', 'salt') }}
   grains:
     region: {{ region|lower }}
 
@@ -15,7 +15,7 @@ rsos_{{ region|lower }}:
   protocol: ipv4
   compute_region: {{ region }}
   provider: openstack
-  user:  {{ cloud['rsos_user'] }}
-  tenant: {{ cloud['rsos_tenant'] }}
-  apikey: {{ cloud['rsos_apikey'] }}
+  user:  {{ cloud.get('rsos_user', 'DEFAULT') }}
+  tenant: {{ cloud.get('rsos_tenant', 'DEFAULT') }}
+  apikey: {{ cloud.get('rsos_apikey', 'DEFAULT') }}
 {% endfor %}

--- a/salt/files/cloud.providers.d/saltify.conf
+++ b/salt/files/cloud.providers.d/saltify.conf
@@ -1,5 +1,8 @@
 # This file is managed by Salt via {{ source }}
+
+{% set cloud = salt['pillar.get']('salt:cloud', {}) -%}
+
 saltify:
   provider: saltify
   minion:
-    master: {{ cloud['master'] }}
+    master: {{ cloud.get('master', 'salt') }}


### PR DESCRIPTION
The default profile and map templates are neither terribly useful nor easy to add to without having to maintain your own fork or extension state. This patch makes the state use file.recurse for those folders (instead of assuming one file per provider) and allows the source property to be set. I don't *think* it can break existing salt trees.

I didn't include providers.d because the templates in there don't gracefully handle missing pillar data.

...but I'm not certain this is actually the best way to do this. I'm looking at the salt.cloud sls, and thinking that with a bit of refactoring the providers, profiles, maps, and file.directory section could all be collapsed into a single loop like the one in this commit -- and be both more flexible and require less pillar configuration afterward. That *would* be a breaking change, though, so I thought I'd ask if it's feasible before going to more effort.

Thoughts?