### PR TITLE
Exclude require statement when install_packages is False.

### DIFF
--- a/salt/ssh.sls
+++ b/salt/ssh.sls
@@ -11,7 +11,7 @@ ensure roster config:
     - name: {{ salt_settings.config_path }}/roster
     - source: salt://salt/files/roster.jinja
     - template: jinja
-    - require:
 {% if salt_settings.install_packages %}
+    - require:
       - pkg: ensure salt-ssh is installed
 {% endif %}


### PR DESCRIPTION
The 'require' statement needs a list as input, but doesn't get
any input when install_packages is set to False.