### PR TITLE
ec2/gce profiles/providers are no longer configured if they are not used

### DIFF
--- a/salt/files/cloud.profiles.d/ec2.conf
+++ b/salt/files/cloud.profiles.d/ec2.conf
@@ -1,4 +1,6 @@
 # This file managed by Salt, do not edit by hand!!
+{% set cloud = salt['pillar.get']('salt:cloud', {}) -%}
+{% if 'aws_key' in cloud %}
 base_ubuntu_ec2:
   provider: ec2_ubuntu_public
   image: ami-cb4986bc
@@ -14,3 +16,4 @@ base_ubuntu_ec2:
         - sg-6ec11d3b
   tag: {'Environment': 'production', 'Role': 'ubuntu'}
   sync_after_install: grains
+{% endif %}

--- a/salt/files/cloud.profiles.d/gce.conf
+++ b/salt/files/cloud.profiles.d/gce.conf
@@ -1,4 +1,6 @@
 # This file managed by Salt, do not edit by hand!!
+{%- set cloud = salt['pillar.get']('salt:cloud', {}) -%}
+{%- if 'gce_project' in cloud %}
 base_debian_gce:
   image: debian-7-wheezy
   size: g1-small
@@ -11,3 +13,4 @@ base_debian_gce:
   deploy: True
   make_master: False
   provider: gce
+{%- endif %}

--- a/salt/files/cloud.providers.d/ec2.conf
+++ b/salt/files/cloud.providers.d/ec2.conf
@@ -1,5 +1,6 @@
 # This file managed by Salt, do not edit by hand!!
 {% set cloud = salt['pillar.get']('salt:cloud', {}) -%}
+{% if 'aws_key' in cloud %}
 ec2_ubuntu_public:
   minion:
     master: {{ cloud.get('master', 'salt') }}
@@ -14,3 +15,4 @@ ec2_ubuntu_public:
   availability_zone: eu-west-1a
   ssh_username: ubuntu
   provider: ec2
+{% endif %}

--- a/salt/files/cloud.providers.d/gce.conf
+++ b/salt/files/cloud.providers.d/gce.conf
@@ -1,5 +1,6 @@
 # This file managed by Salt, do not edit by hand!!
-{% set cloud = salt['pillar.get']('salt:cloud', {}) -%}
+{%- set cloud = salt['pillar.get']('salt:cloud', {}) -%}
+{%- if 'gce_project' in cloud %}
 gce:
   project: "{{ cloud.get('gce_project', 'DEFAULT') }}"
   service_account_email_address: "{{ cloud.get('gce_service_account_email_address', 'DEFAULT') }}"
@@ -9,3 +10,4 @@ gce:
   grains:
     test: True
   provider: gce
+{%- endif %}


### PR DESCRIPTION
I missed something on the last PR. salt-cloud will attempt to load or connect to all the available profiles/providers even if they're not explicitly asked for. Having templates in place with default values produces a bunch of error spam, even though it doesn't stop things from working. I missed that while testing, sorry.

This patch makes the ec2/gce templates blank themselves if the default templates are used and appropriate pillar data isn't present. rsos already has the necessary behavior. Saltify doesn't seem to need it.

There may be a better way to do this; this was just the first method I came up with that required minimal configuration.

Side note: I sort of wonder if it wouldn't be a good idea to have just one default template, that takes the entire provider/profile/map configuration set from the pillar.