### PR TITLE
Default should be against latest version

### DIFF
--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -2,7 +2,7 @@
 # vim: ft=yaml
 salt:
   install_packages: True
-  clean_config_d_dir: True
+  clean_config_d_dir: False
 
   config_path: /etc/salt
 


### PR DESCRIPTION
If it's not recommended to clean config d dir, the default should be False