### PR TITLE
Cleanup template for easier user reading

### DIFF
--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -16,14 +16,10 @@
 ##### Primary configuration settings #####
 ##########################################
 
-# Per default the minion will automatically include all config files
-# from minion.d/*.conf (minion.d is a directory in the same directory
-# as the main minion config file).
+# minion includes
 {{ get_config('default_include', 'minion.d/*.conf') }}
 
-# Set the location of the salt master server. If the master server cannot be
-# resolved, then the minion will fail to start.
-# master:salt
+# master configs
 {%- if 'master' in cfg_minion -%}
 {%- if cfg_minion['master'] is not string %}
 master:
@@ -44,147 +40,87 @@ master:
 {%- endif -%}
 {%- endif %}
 
-# If multiple masters are specified in the 'master' setting, the default behavior
-# is to always try to connect to them in the order they are listed. If random_master is
-# set to True, the order will be randomized instead. This can be helpful in distributing
-# the load of many minions executing salt-call requests, for example, from a cron job.
-# If only one master is listed, this setting is ignored and a warning will be logged.
+# choose a random master
 {{ get_config('random_master', 'False') }}
 
-# Set whether the minion should connect to the master via IPv6:
+# use IPv6
 {{ get_config('ipv6', 'False') }}
 
-# Set the number of seconds to wait before attempting to resolve
-# the master hostname if name resolution fails. Defaults to 30 seconds.
-# Set to zero if the minion should shutdown and not retry.
+# name resolution retries
 {{ get_config('retry_dns', '30') }}
 
-# Set the port used by the master reply and authentication server.
+# master port
 {{ get_config('master_port', '4506') }}
 
-# The user to run salt.
+# user to run salt.
 {{ get_config('user', 'root') }}
 
-# Specify the location of the daemon process ID file.
+# PID file
 {{ get_config('pidfile', '/var/run/salt-minion.pid') }}
 
-# The root directory prepended to these options: pki_dir, cachedir, log_file,
-# sock_dir, pidfile.
+# root dir
 {{ get_config('root_dir', '/') }}
 
-# The directory to store the pki information in
+# pki dir
 {{ get_config('pki_dir', '/etc/salt/pki/minion') }}
 
-# Explicitly declare the id for this minion to use, if left commented the id
-# will be the hostname as returned by the python call: socket.getfqdn()
-# Since salt uses detached ids it is possible to run multiple minions on the
-# same machine but with different ids, this can be useful for salt compute
-# clusters.
+# minion id
 {% if 'id' in cfg_minion -%}
 id: {{ cfg_minion['id'] }}
 {% else -%}
 #id:
 {%- endif %}
 
-# Append a domain to a hostname in the event that it does not exist.  This is
-# useful for systems where socket.getfqdn() does not actually result in a
-# FQDN (for instance, Solaris).
+# domain name for hostnames
 {{ get_config('append_domain', '') }}
 
-# Custom static grains for this minion can be specified here and used in SLS
-# files just like all other grains. This example sets 4 custom grains, with
-# the 'roles' grain having two values that can be matched against.
-#grains:
-#  roles:
-#    - webserver
-#    - memcache
-#  deployment: datacenter4
-#  cabinet: 13
-#  cab_u: 14-15
+# custom grains
 {{ get_config('grains', '{}') }}
 
-# Where cache data goes.
+# cache location
 {{ get_config('cachedir', '/var/cache/salt/minion') }}
 
-# Verify and set permissions on configuration directories at startup.
+# environment verification
 {{ get_config('verify_env', 'True') }}
 
-# The minion can locally cache the return data from jobs sent to it, this
-# can be a good way to keep track of jobs the minion has executed
-# (on the minion side). By default this feature is disabled, to enable, set
-# cache_jobs to True.
+# cache executed jobs
 {{ get_config('cache_jobs', 'False') }}
 
-# Set the directory used to hold unix sockets.
+# unix socket location
 {{ get_config('sock_dir', '/var/run/salt/minion') }}
 
-# Set the default outputter used by the salt-call command. The default is
-# "nested".
+# output formatter
 {{ get_config('output', 'nested') }}
-#
-# By default output is colored. To disable colored output, set the color value
-# to False.
+# output color
 {{ get_config('color', 'True') }}
-
-# Do not strip off the colored output from nested results and state outputs
-# (true by default).
+# remove nested color
 {{ get_config('strip_colors', 'False') }}
 
-# Backup files that are replaced by file.managed and file.recurse under
-# 'cachedir'/file_backups relative to their original location and appended
-# with a timestamp. The only valid setting is "minion". Disabled by default.
-#
-# Alternatively this can be specified for each file in state files:
-# /etc/ssh/sshd_config:
-#   file.managed:
-#     - source: salt://ssh/sshd_config
-#     - backup: minion
-#
+# backup modified files
 {{ get_config('backup_mode', 'minion') }}
 
-# When waiting for a master to accept the minion's public key, salt will
-# continuously attempt to reconnect until successful. This is the time, in
-# seconds, between those reconnection attempts.
+# key acceptance time
 {{ get_config('acceptance_wait_time', '10') }}
-
-# If this is nonzero, the time between reconnection attempts will increase by
-# acceptance_wait_time seconds per iteration, up to this maximum. If this is
-# set to zero, the time between reconnection attempts will stay constant.
+# maximum acceptance wait
 {{ get_config('acceptance_wait_time_max', '0') }}
-
-# If the master rejects the minion's public key, retry instead of exiting.
-# Rejected keys will be handled the same as waiting on acceptance.
+# retry key
 {{ get_config('rejected_retry', 'False') }}
-
-# When the master key changes, the minion will try to re-auth itself to receive
-# the new master key. In larger environments this can cause a SYN flood on the
-# master because all minions try to re-auth immediately. To prevent this and
-# have a minion wait for a random amount of time, use this optional parameter.
-# The wait-time will be a random number of seconds between 0 and the defined value.
+# time to wait for trying reauth
 {{ get_config('random_reauth_delay', '60') }}
-
-# When waiting for a master to accept the minion's public key, salt will
-# continuously attempt to reconnect until successful. This is the timeout value,
-# in seconds, for each individual attempt. After this timeout expires, the minion
-# will wait for acceptance_wait_time seconds before trying again. Unless your master
-# is under unusually heavy load, this should be left at the default.
+# auth wait timeout
 {{ get_config('auth_timeout', '60') }}
-
-# Number of consecutive SaltReqTimeoutError that are acceptable when trying to
-# authenticate.
+# auth retries
 {{ get_config('auth_tries', '7') }}
-
-# If authentication fails due to SaltReqTimeoutError during a ping_interval,
-# cause sub minion process to restart.
+# retry auth if ping failed
 {{ get_config('auth_safemode', 'False') }}
 
-# Ping Master to ensure connection is alive (minutes).
+# master ping interval
 {{ get_config('ping_interval', '0') }}
 
-# The Salt Mine functions are executed when the minion starts and at a given interval by the scheduler.
-# The default interval is every 60 minutes.
+# salt mine functions execution interval
 {{ get_config('mine_interval', '60') }}
 
+# mine functions
 {%- if 'mine_functions' in cfg_minion %}
 mine_functions:
 {%- for func, args in cfg_minion['mine_functions'].items() %}
@@ -192,136 +128,34 @@ mine_functions:
 {%- endfor %}
 {%- endif %}
 
-# To auto recover minions if master changes IP address (DDNS)
-#    auth_tries: 10
-#    auth_safemode: False
-#    ping_interval: 90
-#    restart_on_error: True
-#
-# Minions won't know master is missing until a ping fails. After the ping fail,
-# the minion will attempt authentication and likely fails out and cause a restart.
-# When the minion restarts it will resolve the masters IP and attempt to reconnect.
-
-# If you don't have any problems with syn-floods, don't bother with the
-# three recon_* settings described below, just leave the defaults!
-#
-# The ZeroMQ pull-socket that binds to the masters publishing interface tries
-# to reconnect immediately, if the socket is disconnected (for example if
-# the master processes are restarted). In large setups this will have all
-# minions reconnect immediately which might flood the master (the ZeroMQ-default
-# is usually a 100ms delay). To prevent this, these three recon_* settings
-# can be used.
-# recon_default: the interval in milliseconds that the socket should wait before
-#                trying to reconnect to the master (1000ms = 1 second)
-#
-# recon_max: the maximum time a socket should wait. each interval the time to wait
-#            is calculated by doubling the previous time. if recon_max is reached,
-#            it starts again at recon_default. Short example:
-#
-#            reconnect 1: the socket will wait 'recon_default' milliseconds
-#            reconnect 2: 'recon_default' * 2
-#            reconnect 3: ('recon_default' * 2) * 2
-#            reconnect 4: value from previous interval * 2
-#            reconnect 5: value from previous interval * 2
-#            reconnect x: if value >= recon_max, it starts again with recon_default
-#
-# recon_randomize: generate a random wait time on minion start. The wait time will
-#                  be a random value between recon_default and recon_default +
-#                  recon_max. Having all minions reconnect with the same recon_default
-#                  and recon_max value kind of defeats the purpose of being able to
-#                  change these settings. If all minions have the same values and your
-#                  setup is quite large (several thousand minions), they will still
-#                  flood the master. The desired behavior is to have timeframe within
-#                  all minions try to reconnect.
-#
-# Example on how to use these settings. The goal: have all minions reconnect within a
-# 60 second timeframe on a disconnect.
-# recon_default: 1000
-# recon_max: 59000
-# recon_randomize: True
-#
-# Each minion will have a randomized reconnect value between 'recon_default'
-# and 'recon_default + recon_max', which in this example means between 1000ms
-# 60000ms (or between 1 and 60 seconds). The generated random-value will be
-# doubled after each attempt to reconnect. Lets say the generated random
-# value is 11 seconds (or 11000ms).
-# reconnect 1: wait 11 seconds
-# reconnect 2: wait 22 seconds
-# reconnect 3: wait 33 seconds
-# reconnect 4: wait 44 seconds
-# reconnect 5: wait 55 seconds
-# reconnect 6: wait time is bigger than 60 seconds (recon_default + recon_max)
-# reconnect 7: wait 11 seconds
-# reconnect 8: wait 22 seconds
-# reconnect 9: wait 33 seconds
-# reconnect x: etc.
-#
-# In a setup with ~6000 thousand hosts these settings would average the reconnects
-# to about 100 per second and all hosts would be reconnected within 60 seconds.
+# reconnection parameters
 {{ get_config('recon_default', '100') }}
 {{ get_config('recon_max', '5000') }}
 {{ get_config('recon_randomize', 'False') }}
 
-# The loop_interval sets how long in seconds the minion will wait between
-# evaluating the scheduler and running cleanup tasks. This defaults to a
-# sane 60 seconds, but if the minion scheduler needs to be evaluated more
-# often lower this value
+# minion scheduler interval
 {{ get_config('loop_interval', '60') }}
 
-# The grains_refresh_every setting allows for a minion to periodically check
-# its grains to see if they have changed and, if so, to inform the master
-# of the new grains. This operation is moderately expensive, therefore
-# care should be taken not to set this value too low.
-#
-# Note: This value is expressed in __minutes__!
-#
-# A value of 10 minutes is a reasonable default.
-#
-# If the value is set to zero, this check is disabled.
+# grain refresh interval
 {{ get_config('grains_refresh_every', '1') }}
-
-# Cache grains on the minion. Default is False.
+# cache grains in minion
 {{ get_config('grains_cache', 'False') }}
-
-# Grains cache expiration, in seconds. If the cache file is older than this
-# number of seconds then the grains cache will be dumped and fully re-populated
-# with fresh data. Defaults to 5 minutes. Will have no effect if 'grains_cache'
-# is not enabled.
+# grains cache expiration interval
 {{ get_config('grains_cache_expiration', '300') }}
 
-# Windows platforms lack posix IPC and must rely on slower TCP based inter-
-# process communications. Set ipc_mode to 'tcp' on such systems
+# ipc method
 {{ get_config('ipc_mode', 'ipc') }}
-
-# Overwrite the default tcp ports used by the minion when in tcp mode
+# ipc tcp ports
 {{ get_config('tcp_pub_port', '4510') }}
 {{ get_config('tcp_pull_port', '4511') }}
 
-# Passing very large events can cause the minion to consume large amounts of
-# memory. This value tunes the maximum size of a message allowed onto the
-# minion event bus. The value is expressed in bytes.
+# max event size in minion bus
 {{ get_config('max_event_size', '1048576') }}
 
-# To detect failed master(s) and fire events on connect/disconnect, set
-# master_alive_interval to the number of seconds to poll the masters for
-# connection events.
-#
+# master check alive interval
 {{ get_config('master_alive_interval', '30') }}
 
-# The minion can include configuration from other files. To enable this,
-# pass a list of paths to this option. The paths can be either relative or
-# absolute; if relative, they are considered to be relative to the directory
-# the main minion configuration file lives in (this file). Paths can make use
-# of shell-style globbing. If no files are matched by a path passed to this
-# option then the minion will log a warning message.
-#
-# Include a config file from some other path:
-# include: /etc/salt/extra_config
-#
-# Include config from several files and directories:
-#include:
-#  - /etc/salt/extra_config
-#  - /etc/roles/webserver
+# include extra config
 {% if 'include' in cfg_minion -%}
     {% if isinstance(cfg_minion['include'], list) -%}
         include:
@@ -345,169 +179,69 @@ mine_functions:
 
 #####   Minion module management     #####
 ##########################################
-# Disable specific modules. This allows the admin to limit the level of
-# access the master has to the minion.
+# disable modules
 {{ get_config('disable_modules', '[cmd,test]') }}
 {{ get_config('disable_returners', '[]') }}
 #
-# Modules can be loaded from arbitrary paths. This enables the easy deployment
-# of third party modules. Modules for returners and minions can be loaded.
-# Specify a list of extra directories to search for minion modules and
-# returners. These paths must be fully qualified!
+# minion modules search paths
 {{ get_config('module_dirs', '[]') }}
 {{ get_config('returner_dirs', '[]') }}
 {{ get_config('states_dirs', '[]') }}
 {{ get_config('render_dirs', '[]') }}
 {{ get_config('utils_dirs', '[]') }}
-#
-# A module provider can be statically overwritten or extended for the minion
-# via the providers option, in this case the default module will be
-# overwritten by the specified module. In this example the pkg module will
-# be provided by the yumpkg5 module instead of the system default.
-#providers:
-#  pkg: yumpkg5
+# module overrides
 {{ get_config('providers', '{}') }}
-#
-# Enable Cython modules searching and loading. (Default: False)
+# enable cython modules
 {{ get_config('cython_enable', 'False') }}
-#
-# Specify a max size (in bytes) for modules on import. This feature is currently
-# only supported on *nix operating systems and requires psutil.
+# max module size
 {{ get_config('modules_max_memory', '-1') }}
 
 
 #####    State Management Settings    #####
 ###########################################
-# The state management system executes all of the state templates on the minion
-# to enable more granular control of system state management. The type of
-# template and serialization used for state management needs to be configured
-# on the minion, the default renderer is yaml_jinja. This is a yaml file
-# rendered from a jinja template, the available options are:
-# yaml_jinja
-# yaml_mako
-# yaml_wempy
-# json_jinja
-# json_mako
-# json_wempy
-#
+# renderer selection
 {{ get_config('renderer', 'yaml_jinja') }}
-#
-# The failhard option tells the minions to stop immediately after the first
-# failure detected in the state execution. Defaults to False.
+# fail on first failure
 {{ get_config('failhard', 'False') }}
-#
-# autoload_dynamic_modules turns on automatic loading of modules found in the
-# environments on the master. This is turned on by default. To turn of
-# autoloading modules when states run, set this value to False.
+# auto reload dynamic modules
 {{ get_config('autoload_dynamic_modules', 'True') }}
-#
-# clean_dynamic_modules keeps the dynamic modules on the minion in sync with
-# the dynamic modules on the master, this means that if a dynamic module is
-# not on the master it will be deleted from the minion. By default, this is
-# enabled and can be disabled by changing this value to False.
+# sync dynamic modules with deletion
 {{ get_config('clean_dynamic_modules', 'True') }}
-#
-# Normally, the minion is not isolated to any single environment on the master
-# when running states, but the environment can be isolated on the minion side
-# by statically setting it. Remember that the recommended way to manage
-# environments is to isolate via the top file.
+# minion accepted environment
 {{ get_config('environment', 'None') }}
-#
-# If using the local file directory, then the state top file name needs to be
-# defined, by default this is top.sls.
+# top state file
 {{ get_config('state_top', 'top.sls') }}
-#
-# Run states when the minion daemon starts. To enable, set startup_states to:
-# 'highstate' -- Execute state.highstate
-# 'sls' -- Read in the sls_list option and execute the named sls files
-# 'top' -- Read top_file option and execute based on that file on the Master
+# states to run in minion daemon
 {{ get_config('startup_states', "''") }}
-#
-# List of states to run when the minion starts up if startup_states is 'sls':
-#sls_list:
-#  - edit.vim
-#  - hyper
+# sls states to run
 {{ get_config('sls_list', '[]') }}
-#
-# Top file to execute if startup_states is 'top':
+# top file to run
 {{ get_config('top_file', "''") }}
-
-# Automatically aggregate all states that have support for mod_aggregate by
-# setting to True. Or pass a list of state module names to automatically
-# aggregate just those types.
-#
-# state_aggregate:
-#   - pkg
-#
-#state_aggregate: False
 
 #####     File Directory Settings    #####
 ##########################################
-# The Salt Minion can redirect all file server operations to a local directory,
-# this allows for the same state tree that is on the master to be used if
-# copied completely onto the minion. This is a literal copy of the settings on
-# the master but used to reference a local directory on the minion.
-
-# Set the file client. The client defaults to looking on the master server for
-# files, but can be directed to look at the local file directory setting
-# defined below by setting it to local.
+# file client location
 {%- if standalone %}
 file_client: local
 {%- else %}
 {{ get_config('file_client', 'remote') }}
 {%- endif %}
 
-# The file directory works on environments passed to the minion, each environment
-# can have multiple root directories, the subdirectories in the multiple file
-# roots cannot match, otherwise the downloaded files will not be able to be
-# reliably ensured. A base environment is required to house the top file.
-# Example:
-# file_roots:
-#   base:
-#     - /srv/salt/
-#   dev:
-#     - /srv/salt/dev/services
-#     - /srv/salt/dev/states
-#   prod:
-#     - /srv/salt/prod/services
-#     - /srv/salt/prod/states
-#
+# environment file roots
 {% if 'file_roots' in cfg_minion -%}
 {{ file_roots(cfg_minion['file_roots']) }}
 {%- elif 'file_roots' in cfg_salt -%}
 {{ file_roots(cfg_salt['file_roots']) }}
 {%- elif formulas|length -%}
 {{ file_roots({'base': ['/srv/salt']}) }}
-{%- else -%}
-#file_roots:
-#  base:
-#    - /srv/salt
 {%- endif %}
 
-# By default, the Salt fileserver recurses fully into all defined environments
-# to attempt to find files. To limit this behavior so that the fileserver only
-# traverses directories with SLS files and special Salt directories like _modules,
-# enable the option below. This might be useful for installations where a file root
-# has a very large number of files and performance is negatively impacted. Default
-# is False.
+# limit fileserver traversal
 {{ get_config('fileserver_limit_traversal', 'False') }}
 
-#
-# Git fileserver backend configuration
-#
-# Gitfs can be provided by one of two python modules: GitPython or pygit2. If
-# using pygit2, both libgit2 and git must also be installed.
+# gitfs provider
 {{ get_config('gitfs_provider', 'pygit2') }}
-#
-# When using the git fileserver backend at least one git remote needs to be
-# defined. The user running the salt master will need read access to the repo.
-#
-# The repos will be searched in order to find the file requested by a client
-# and the first repo to have the file will return it.
-# When using the git backend branches and tags are translated into salt
-# environments.
-# Note:  file:// repos will be treated as a remote, so refs you want used must
-# exist in that repo as *local* refs.
+# gitfs remotes
 {% if 'gitfs_remotes' in cfg_minion -%}
 gitfs_remotes:
 {%- for remote in cfg_minion['gitfs_remotes'] %}
@@ -525,34 +259,15 @@ gitfs_remotes:
 {%- endif -%}
 {%- endfor -%}
 {%- endif %}
-#
-#gitfs_remotes:
-#  - git://github.com/saltstack/salt-states.git
-#  - file:///var/git/saltmaster
-#
-# The gitfs_ssl_verify option specifies whether to ignore ssl certificate
-# errors when contacting the gitfs backend. You might want to set this to
-# false if you're using a git backend that uses a self-signed certificate but
-# keep in mind that setting this flag to anything other than the default of True
-# is a security concern, you may want to try using the ssh transport.
+# verify git ssl errors
 {{ get_config('gitfs_ssl_verify', 'True') }}
- 
-# The gitfs_root option gives the ability to serve files from a subdirectory
-# within the repository. The path is defined relative to the root of the
-# repository and defaults to the repository root.
+# gitfs root dir
 {{ get_config('gitfs_root', 'somefolder/otherfolder') }}
- 
-# The hash_type is the hash to use when discovering the hash of a file in
-# the local fileserver. The default is md5, but sha1, sha224, sha256, sha384
-# and sha512 are also supported.
-#
-# Warning: Prior to changing this value, the minion should be stopped and all
-# Salt caches should be cleared.
+
+# file hash method
 {{ get_config('hash_type', 'md5') }}
 
-# The Salt pillar is searched for locally if file_client is set to local. If
-# this is the case, and pillar data is defined, then the pillar_roots need to
-# also be configured on the minion:
+# pillar roots
 {% if 'pillar_roots' in cfg_minion -%}
 pillar_roots:
 {%- for name, roots in cfg_minion['pillar_roots']|dictsort %}
@@ -569,119 +284,58 @@ pillar_roots:
     - {{ dir }}
 {%- endfor -%}
 {%- endfor -%}
-{% else -%}
-#pillar_roots:
-#  base:
-#    - /srv/salt
 {%- endif %}
 
 
 ######        Security settings       #####
 ###########################################
-# Enable "open mode", this mode still maintains encryption, but turns off
-# authentication, this is only intended for highly secure environments or for
-# the situation where your keys end up in a bad state. If you run in open mode
-# you do so at your own risk!
+# disable authentication
 {{ get_config('open_mode', 'False') }}
-
-# Enable permissive access to the salt keys.  This allows you to run the
-# master or minion as root, but have a non-root group be given access to
-# your pki_dir.  To make the access explicit, root must belong to the group
-# you've given access to. This is potentially quite insecure.
+# allow access to pki dir
 {{ get_config('permissive_pki_access', 'False') }}
 
-# The state_verbose and state_output settings can be used to change the way
-# state system data is printed to the display. By default all data is printed.
-# The state_verbose setting can be set to True or False, when set to False
-# all data that has a result of True and no changes will be suppressed.
+# print verbose changes
 {{ get_config('state_verbose', 'True') }}
-
-# The state_output setting changes if the output is the full multi line
-# output for each changed state if set to 'full', but if set to 'terse'
-# the output will be shortened to a single line.
+# multi line output
 {{ get_config('state_output', 'full') }}
-
-# The state_output_diff setting changes whether or not the output from
-# successful states is returned. Useful when even the terse output of these
-# states is cluttering the logs. Set it to True to ignore them.
+# output diff
 {{ get_config('state_output_diff', 'False') }}
 
-# Fingerprint of the master public key to double verify the master is valid,
-# the master fingerprint can be found by running "salt-key -F master" on the
-# salt master.
+# master fingerprint
 {{ get_config('master_finger', "''") }}
 
 ######         Thread settings        #####
 ###########################################
-# Disable multiprocessing support, by default when a minion receives a
-# publication a new process is spawned and the command is executed therein.
+# enable multiprocessing
 {{ get_config('multiprocessing', 'True') }}
 
 
 #####         Logging settings       #####
 ##########################################
-# The location of the minion log file
-# The minion log can be sent to a regular file, local path name, or network
-# location. Remote logging works best when configured to use rsyslogd(8) (e.g.:
-# ``file:///dev/log``), with rsyslogd(8) configured for network logging. The URI
-# format is: <file|udp|tcp>://<host|socketpath>:<port-if-required>/<log-facility>
-#log_file: /var/log/salt/minion
-#log_file: file:///dev/log
-#log_file: udp://loghost:10514
-#
+# log file and log lock file location
 {{ get_config('log_file', '/var/log/salt/minion') }}
 {{ get_config('key_logfile', ' /var/log/salt/key') }}
 
-# The level of messages to send to the console.
-# One of 'garbage', 'trace', 'debug', info', 'warning', 'error', 'critical'.
-# Default: 'warning'
+# console log level
 {{ get_config('log_level', 'warning') }}
-
-# The level of messages to send to the log file.
-# One of 'garbage', 'trace', 'debug', info', 'warning', 'error', 'critical'.
-# If using 'log_granular_levels' this must be set to the highest desired level.
-# Default: 'warning'
+# logfile log level
 {{ get_config('log_level_logfile', '') }}
 
-# The date and time format used in log messages. Allowed date/time formating
-# can be seen here: http://docs.python.org/library/time.html#time.strftime
+# datetime format for console and logfile
 {{ get_config('log_datefmt', "'%H:%M:%S'") }}
 {{ get_config('log_datefmt_logfile', "'%Y-%m-%d %H:%M:%S'") }}
 
-# The format of the console logging messages. Allowed formatting options can
-# be seen here: http://docs.python.org/library/logging.html#logrecord-attributes
+# log format for console and logfiles
 {{ get_config('log_fmt_console', "'[%(levelname)-8s] %(message)s'") }}
 {{ get_config('log_fmt_logfile', "'%(asctime)s,%(msecs)03.0f [%(name)-17s][%(levelname)-8s] %(message)s'") }}
 
-# This can be used to control logging levels more specificically.  This
-# example sets the main salt library at the 'warning' level, but sets
-# 'salt.modules' to log at the 'debug' level:
-#   log_granular_levels:
-#     'salt': 'warning'
-#     'salt.modules': 'debug'
-#
+# log particular modules
 {{ get_config('log_granular_levels', '{}') }}
 
 
 ######      Module configuration      #####
 ###########################################
-# Salt allows for modules to be passed arbitrary configuration data, any data
-# passed here in valid yaml format will be passed on to the salt minion modules
-# for use. It is STRONGLY recommended that a naming convention be used in which
-# the module name is followed by a . and then the value. Also, all top level
-# data must be applied via the yaml dict construct, some examples:
-#
-# You can specify that all modules should run in test mode:
-#test: True
-#
-# A simple value for the test module:
-#test.foo: foo
-#
-# A list for the test module:
-#test.bar: [baz,quo]
-#
-# A dict for the test module:
-#test.baz: {spam: sausage, cheese: bread}
+# module parameters
 {%- if 'module_config' in cfg_minion %}
 {%- for modkey, modval in cfg_minion.module_config.items() %}
 {{ modkey }}: {{ modval }}
@@ -691,51 +345,25 @@ pillar_roots:
 
 ######      Update settings          ######
 ###########################################
-# Using the features in Esky, a salt minion can both run as a frozen app and
-# be updated on the fly. These options control how the update process
-# (saltutil.update()) behaves.
-#
-# The url for finding and downloading updates. Disabled by default.
+# update url
 {{ get_config('update_url', 'False') }}
-#
-# The list of services to restart after a successful update. Empty by default.
+# services to restart after update
 {{ get_config('update_restart_services', '[]') }}
 
 
 ######      Keepalive settings        ######
 ############################################
-# ZeroMQ now includes support for configuring SO_KEEPALIVE if supported by
-# the OS. If connections between the minion and the master pass through
-# a state tracking device such as a firewall or VPN gateway, there is
-# the risk that it could tear down the connection the master and minion
-# without informing either party that their connection has been taken away.
-# Enabling TCP Keepalives prevents this from happening.
-
-# Overall state of TCP Keepalives, enable (1 or True), disable (0 or False)
-# or leave to the OS defaults (-1), on Linux, typically disabled. Default True, enabled.
+# use tcp keepalive
 {{ get_config('tcp_keepalive', 'True') }}
-
-# How long before the first keepalive should be sent in seconds. Default 300
-# to send the first keepalive after 5 minutes, OS default (-1) is typically 7200 seconds
-# on Linux see /proc/sys/net/ipv4/tcp_keepalive_time.
+# first keepalive from idle
 {{ get_config('tcp_keepalive_idle', '300') }}
-
-# How many lost probes are needed to consider the connection lost. Default -1
-# to use OS defaults, typically 9 on Linux, see /proc/sys/net/ipv4/tcp_keepalive_probes.
+# keepalive number for connection lost
 {{ get_config('tcp_keepalive_cnt', '-1') }}
-
-# How often, in seconds, to send keepalives after the first one. Default -1 to
-# use OS defaults, typically 75 seconds on Linux, see
-# /proc/sys/net/ipv4/tcp_keepalive_intvl.
+# keepalive interval
 {{ get_config('tcp_keepalive_intvl', '-1') }}
 
 
 ######      Windows Software settings ######
 ############################################
-# Location of the repository cache file on the master:
+# windows repo cache
 {{ get_config('win_repo_cachefile', 'salt://win/repo/winrepo.p') }}
-
-######      Returner  settings        ######
-############################################
-# Which returner(s) will be used for minion's result:
-#return: mysql


### PR DESCRIPTION
The user will already have it's /etc/salt/minion file, so it doesn't need all this info, and it makes easier to know what has been generated and what not