### PR TITLE
add pillar_roots for minion and master in pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -27,7 +27,9 @@ salt:
     file_roots:
       base:
         - /srv/salt
-
+    pillar_roots:
+      base:
+        - /srv/pillar
     # for salt-api with tornado rest interface
     rest_tornado:
       port: 8000
@@ -56,6 +58,9 @@ salt:
     file_roots:
       base:
         - /srv/salt
+    pillar_roots:
+      base:
+        - /srv/pillar
     module_config:
       test: True
       test.foo: foo


### PR DESCRIPTION
pillar_roots definitions are missing from pillar.example

I believe this is an afterthought, thus I have added them to pillar.example