### PR TITLE
Fix pillar_roots configuration format in master

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -662,7 +662,7 @@ pillar_roots:
 #pillar_roots:
 #  base:
 #    - /srv/pillar
-{%- endif -%}
+{%- endif %}
 #
 {% if 'ext_pillar' in cfg_master %}
 ext_pillar:

--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -642,27 +642,27 @@ gitfs_remotes:
 # Pillar is laid out in the same fashion as the file server, with environments,
 # a top file and sls files. However, pillar data does not need to be in the
 # highstate format, and is generally just key/value pairs.
-{% if 'pillar_roots' in cfg_master %}
+{% if 'pillar_roots' in cfg_master -%}
 pillar_roots:
-{% for name, roots in cfg_master['pillar_roots']|dictsort %}
+{%- for name, roots in cfg_master['pillar_roots']|dictsort %}
   {{ name }}:
-{% for dir in roots %}
+{%- for dir in roots %}
     - {{ dir }}
+{%- endfor -%}
 {% endfor %}
-{% endfor %}
-{% elif 'pillar_roots' in cfg_salt %}
+{%- elif 'pillar_roots' in cfg_salt -%}
 pillar_roots:
-{% for name, roots in cfg_salt['pillar_roots']|dictsort %}
+{%- for name, roots in cfg_salt['pillar_roots']|dictsort -%}
   {{ name }}:
-{% for dir in roots %}
+{%- for dir in roots -%}
     - {{ dir }}
-{% endfor %}
-{% endfor %}
-{% else %}
+{%- endfor -%}
+{%- endfor -%}
+{%- else -%}
 #pillar_roots:
 #  base:
 #    - /srv/pillar
-{% endif %}
+{%- endif -%}
 #
 {% if 'ext_pillar' in cfg_master %}
 ext_pillar:


### PR DESCRIPTION
This commit fixes how `pillar_roots` are generated and after this fix the
generated configuration does not contain any unnecessary new lines:

```yaml
pillar_roots:
  base:
     /srv/salt/dir1
  dev:
     /srv/salt/dir2
     /srv/salt/dir3
  locale:
     /srv/salt/dir4
```

Before this commit the pillar_roots in `f_defaults.conf` for master would be
generated with a lot of empty lines in between directories, like this:

```yaml
pillar_roots:

  base:

     /srv/salt/dir1

  dev:

     /srv/salt/dir2

     /srv/salt/dir3

  local:

     /srv/salt/dir4

```

The minion configuration is not affected and renders fine.