### PR TITLE
Improved support for Enterprise Linux family OSs (CentOS, RHEL etc)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,7 @@ Install gitfs backend GitPython dependenciess. Set ``salt:master:gitfs_provider:
 ----------------------
 
 Install gitfs backend libgit2/pygit2 dependenciess. Set ``salt:master:gitfs_provider: pygit2`` in your pillar.
+For EL distributions, pygit is installed from packages from `EPEL <https://github.com/saltstack-formulas/epel-formula>`_.
 
 ``salt.pkgrepo``
 ----------------
@@ -76,6 +77,8 @@ benefit from the latest version. This state currently only works on Debian
 and Ubuntu, and aims to implement the `installation recommendations of the
 official documentation
 <http://docs.saltstack.com/en/latest/topics/installation/index.html#platform-specific-installation-instructions>`_.
+
+On EL distributions, the official Salt `COPR for ZeroMQ 4 <http://copr.fedoraproject.org/coprs/saltstack/zeromq4/>`_. Salt itself is installed via `EPEL <https://github.com/saltstack-formulas/epel-formula>`_.
 
 ``salt.pkgrepo.absent``
 -----------------------

--- a/salt/gitfs/pygit2.sls
+++ b/salt/gitfs/pygit2.sls
@@ -53,8 +53,7 @@ install-pygit2:
     - name: pygit2
 
 {% else %}
-# install from package
-# TODO haven't actually found a distro that has a good version to test
-# debian jessie will have libgit2-21
+{{ salt_settings.pygit2 }}:
+  pkg.installed
 
 {% endif %}

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -14,7 +14,18 @@ that differ from whats in defaults.yaml
     'CentOS':  {},
     'Amazon':  {},
     'Fedora':  {},
-    'RedHat':  {},
+    'RedHat':  {
+      'pygit2': 'python-pygit2',
+      'gitfs': {
+        'pygit2': {
+           'install_from_source': False
+        },
+      },
+      'master': {
+        'gitfs_provider': 'pygit2'
+      },
+      'repotype': 'epel'
+    },
     'Suse':    {},
     'Gentoo':  {
       'salt_master': 'app-admin/salt',

--- a/salt/pkgrepo/init.sls
+++ b/salt/pkgrepo/init.sls
@@ -1,4 +1,6 @@
-{% if grains['os_family'] == 'Debian' %}
+{% set name = {
+    'RedHat': 'redhat',
+    'Debian': grains['os']|lower,
+}.get(grains.os_family) %}
 include:
-  - .{{ grains['os']|lower }}
-{% endif %}
+  - .{{ name }}

--- a/salt/pkgrepo/redhat/init.sls
+++ b/salt/pkgrepo/redhat/init.sls
@@ -1,0 +1,10 @@
+{% from "salt/map.jinja" import salt_settings with context %}
+
+saltstack-zeromq4:
+  pkgrepo.managed:
+    - humanname: Copr repo for zeromq4 owned by saltstack
+    - baseurl: http://copr-be.cloud.fedoraproject.org/results/saltstack/zeromq4/{{ salt_settings.repotype }}-$releasever-$basearch/
+    - gpgcheck: 1
+    - gpgkey: https://copr-be.cloud.fedoraproject.org/results/saltstack/zeromq4/pubkey.gpg
+    - skip_if_unavailable: True
+    - enabled: 1


### PR DESCRIPTION
* Install pygit from package
* Add Official Salt ZeroMQ 4 COPR repository

Note that Salt itself is assumed to already to be available to the system via yum, via EPEL for example