### PR TITLE
The git command line tool is a requirement of pygit2

### DIFF
--- a/salt/gitfs/pygit2.sls
+++ b/salt/gitfs/pygit2.sls
@@ -1,5 +1,8 @@
 {% from "salt/map.jinja" import salt_settings with context %}
 
+git:
+  pkg.installed
+
 {% if salt_settings.gitfs.pygit2.install_from_source %}
 # we probably don't have a package or it's not a high enough version
 # install latest from source/pip


### PR DESCRIPTION
Pygit2 requires git itself. This installs it in all cases.