### PR TITLE
Remove hardcoded paths with {{ slspath }} variable

### DIFF
--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -37,7 +37,7 @@ salt-cloud:
 cloud-cert-{{ cert }}-pem:
   file.managed:
     - name: /etc/salt/pki/cloud/{{ cert }}.pem
-    - source: salt://salt/files/key
+    - source: salt://{{ slspath }}/files/key
     - template: jinja
     - user: root
     - group: root

--- a/salt/master.sls
+++ b/salt/master.sls
@@ -8,7 +8,7 @@ salt-master:
   file.recurse:
     - name: {{ salt_settings.config_path }}/master.d
     - template: jinja
-    - source: salt://salt/files/master.d
+    - source: salt://{{ slspath }}/files/master.d
     - clean: {{ salt_settings.clean_config_d_dir }}
     - exclude_pat: _*
   service.running:

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -8,7 +8,7 @@ salt-minion:
   file.recurse:
     - name: {{ salt_settings.config_path }}/minion.d
     - template: jinja
-    - source: salt://salt/files/minion.d
+    - source: salt://{{ slspath }}/files/minion.d
     - clean: {{ salt_settings.clean_config_d_dir }}
     - exclude_pat: _*
     - context:

--- a/salt/pkgrepo/debian/init.sls
+++ b/salt/pkgrepo/debian/init.sls
@@ -1,7 +1,7 @@
 saltstack-apt-key:
   file.managed:
     - name: /etc/apt/trusted.gpg.d/saltstack.gpg
-    - source: salt://salt/pkgrepo/debian/saltstack.gpg
+    - source: salt://{{ slspath }}/saltstack.gpg
     - user: root
     - group: root
     - mode: 644
@@ -9,7 +9,7 @@ saltstack-apt-key:
 saltstack-pkgrepo:
   file.managed:
     - name: /etc/apt/sources.list.d/saltstack.list
-    - source: salt://salt/pkgrepo/debian/sources.list
+    - source: salt://{{ slspath }}/sources.list
     - user: root
     - group: root
     - mode: 644

--- a/salt/ssh.sls
+++ b/salt/ssh.sls
@@ -9,7 +9,7 @@ ensure-salt-ssh-is-installed:
 ensure-roster-config:
   file.managed:
     - name: {{ salt_settings.config_path }}/roster
-    - source: salt://salt/files/roster.jinja
+    - source: salt://{{ slspath }}/files/roster.jinja
     - template: jinja
 {% if salt_settings.install_packages %}
     - require:

--- a/salt/standalone.sls
+++ b/salt/standalone.sls
@@ -8,7 +8,7 @@ salt-minion:
   file.recurse:
     - name: {{ salt_settings.config_path }}/minion.d
     - template: jinja
-    - source: salt://salt/files/minion.d
+    - source: salt://{{ slspath }}/files/minion.d
     - clean: {{ salt_settings.clean_config_d_dir }}
     - exclude_pat: _*
     - context:


### PR DESCRIPTION
Please test this, it works on 2015.5.x but {{ slspath }} isn't available on 2014.1 and below,

see also this issue : https://github.com/saltstack/salt/issues/4348
