### PR TITLE
formulas.jinja: python 2.6 support

### DIFF
--- a/salt/formulas.jinja
+++ b/salt/formulas.jinja
@@ -8,8 +8,8 @@
 {% set formulas = salt['pillar.get']('salt_formulas:list', {}) %}
 
 {%- macro formulas_git_opt(env, opt) -%}
-{%- set value = salt['pillar.get']('salt_formulas:git_opts:{}:{}'.format(env, opt),
-     salt['pillar.get']('salt_formulas:git_opts:default:{}'.format(opt),
+{%- set value = salt['pillar.get']('salt_formulas:git_opts:{0}:{1}'.format(env, opt),
+     salt['pillar.get']('salt_formulas:git_opts:default:{0}'.format(opt),
        defaults[opt])) -%}
 {%- if value is mapping -%}
 {{ value|yaml }}
@@ -21,7 +21,7 @@
 {%- macro formulas_roots(env) -%}
 {%- set value = [] -%}
 {%- for dir in formulas.get(env, []) -%}
-{%- do value.append('{}/{}'.format(formulas_git_opt(env, 'basedir'), dir)) -%}
+{%- do value.append('{0}/{1}'.format(formulas_git_opt(env, 'basedir'), dir)) -%}
 {%- endfor -%}
 {{ value|yaml }}
 {%- endmacro -%}


### PR DESCRIPTION
As described in https://docs.python.org/2/library/string.html
> Changed in version 2.7: The positional argument specifiers can be omitted, so '{} {}' is equivalent to '{0} {1}'.

In python 2.6 this feature is not available.
CentOS 6.5 still has python 2.6, so it would be nice to support it.