### PR TITLE
formulas.jinja: python 2.6 support

### DIFF
--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -8,7 +8,7 @@
 {% for entry in entries %}
 
 {% set basedir = formulas_git_opt(env, 'basedir') %}
-{% set gitdir = '{}/{}'.format(basedir, entry) %}
+{% set gitdir = '{0}/{1}'.format(basedir, entry) %}
 {% set update = formulas_git_opt(env, 'update')|load_yaml %}
 
 # Setup the directory hosting the Git repository


### PR DESCRIPTION
This is follow up for #144 (Forgot to fix same issue in formulas.sls)

As described in https://docs.python.org/2/library/string.html
> Changed in version 2.7: The positional argument specifiers can be omitted, so '{} {}' is equivalent to '{0} {1}'.

In python 2.6 this feature is not available.
CentOS 6.5 still has python 2.6, so it would be nice to support it.