### PR TITLE
Fix syndic requisites

### DIFF
--- a/salt/syndic.sls
+++ b/salt/syndic.sls
@@ -8,12 +8,11 @@ salt-syndic:
   pkg.installed:
     - name: {{ salt_settings.salt_syndic }}
 {% endif %}
-  service:
-    - running
+  service.running
     - require:
-      - service: {{ salt_settings.syndic_service }}
+      - service: salt-master
     - watch:
 {% if salt_settings.install_packages %}
       - pkg: salt-master
 {% endif %}
-      - file: {{ salt_settings.config_path }}/master
+      - file: salt-master


### PR DESCRIPTION
The syndic service was depending upon itself, which caused the salt run
to fail. This commit fixes that by depending on the salt-master service
rather than the salt-syndic service. I also made it more general by
using IDs to specify the provider rather than the name, which is a bit
less reliable.