### PR TITLE
Add support for GitPython and salt-ssh on FreeBSD masters

### DIFF
--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -18,6 +18,7 @@ salt:
   salt_api: salt-api
   salt_ssh: salt-ssh
 
+  python_git: python-git
   python_cherrypy: python-cherrypy
   python_tornado: python-tornado
 

--- a/salt/gitfs/gitpython.sls
+++ b/salt/gitfs/gitpython.sls
@@ -8,6 +8,7 @@ GitPython:
 {% else %}
 
 python-git:
-  pkg.installed
+  pkg.installed:
+    - name: {{ salt_settings['python_git'] }}
 
 {% endif %}

--- a/salt/gitfs/gitpython.sls
+++ b/salt/gitfs/gitpython.sls
@@ -9,6 +9,6 @@ GitPython:
 
 python-git:
   pkg.installed:
-    - name: {{ salt_settings['python_git'] }}
+    - name: {{ salt_settings.python_git }}
 
 {% endif %}

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -48,6 +48,8 @@ that differ from whats in defaults.yaml
       'salt_syndic': 'py27-salt',
       'salt_cloud': 'py27-salt',
       'salt_api': 'py27-salt',
+      'salt_ssh': 'py27-salt',
+      'python_git': 'py27-GitPython',
       'config_path': '/usr/local/etc/salt',
       'minion_service': 'salt_minion',
       'master_service': 'salt_master',


### PR DESCRIPTION
This change tweaks the GitPython package installation state to support
alternate package names (on FreeBSD, it's called "py27-GitPython").
Also, on FreeBSD salt-ssh is included in the "py27-salt" package by
default, requiring an update to `distro_map`.