### PR TITLE
Use the py27-salt package when installing salt-ssh on FreeBSD

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -48,6 +48,7 @@ that differ from whats in defaults.yaml
       'salt_syndic': 'py27-salt',
       'salt_cloud': 'py27-salt',
       'salt_api': 'py27-salt',
+      'salt_ssh': 'py27-salt',
       'config_path': '/usr/local/etc/salt',
       'minion_service': 'salt_minion',
       'master_service': 'salt_master',


### PR DESCRIPTION
On FreeBSD salt-ssh gets bundled into a single package with the other
SaltStack components (minion, master, etc.).