### PR TITLE
Use the py27-GitPython package when installing GitPython on FreeBSD

### DIFF
--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -18,6 +18,8 @@ salt:
   salt_api: salt-api
   salt_ssh: salt-ssh
 
+  python_git: python-git
+
   master:
     gitfs_provider: gitpython
 

--- a/salt/gitfs/gitpython.sls
+++ b/salt/gitfs/gitpython.sls
@@ -8,6 +8,7 @@ GitPython:
 {% else %}
 
 python-git:
-  pkg.installed
+  pkg.installed:
+    - name: {{ salt_settings.python_git }}
 
 {% endif %}

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -48,6 +48,7 @@ that differ from whats in defaults.yaml
       'salt_syndic': 'py27-salt',
       'salt_cloud': 'py27-salt',
       'salt_api': 'py27-salt',
+      'python_git': 'py27-GitPython',
       'config_path': '/usr/local/etc/salt',
       'minion_service': 'salt_minion',
       'master_service': 'salt_master',


### PR DESCRIPTION
Note that this requires alterations to both *salt/defaults.yaml* and *salt/map.jinja* to allow customization of the GitPython package name.