### PR TITLE
Add options for mult-master setup

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -375,6 +375,9 @@ client_acl_blacklist:
 {{ get_config('sign_pub_message', 'False') }}
 
 
+{{ get_config('master_sign_pubkey', 'False') }}
+
+
 #####    Master Module Management    #####
 ##########################################
 # Manage how master side modules are loaded.

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -155,6 +155,9 @@ mine_functions:
 # master check alive interval
 {{ get_config('master_alive_interval', '30') }}
 
+# verify_master_pubkey_sign
+{{ get_config('verify_master_pubkey_sign', 'False') }}
+
 # include extra config
 {% if 'include' in cfg_minion -%}
     {% if isinstance(cfg_minion['include'], list) -%}


### PR DESCRIPTION
The two options ``master_sign_pubkey`` and ``verify_master_pubkey_sign`` are needed for proper mutli-master setup with failover. The setup is described [here](http://docs.saltstack.com/en/latest/topics/tutorials/multimaster_pki.html).

Somehow they are not present in [master configuration](https://github.com/saltstack/salt/blob/develop/conf/master), but actually work.