### PR TITLE
Add master_type option

### DIFF
--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -157,6 +157,7 @@ mine_functions:
 
 # verify_master_pubkey_sign
 {{ get_config('verify_master_pubkey_sign', 'False') }}
+{{ get_config('master_type', 'str') }}
 
 # include extra config
 {% if 'include' in cfg_minion -%}


### PR DESCRIPTION
The multi-master setup (support of which I added in #161) won't actually work without this paramter.
Sorry for forgeting that in first PR.