### PR TITLE
Configure the salt-api service to start at boot time

### DIFF
--- a/salt/api.sls
+++ b/salt/api.sls
@@ -9,6 +9,7 @@ salt-api:
     - name: {{ salt_settings.salt_api }}
 {% endif %}
   service.running:
+    - enable: True
     - name: {{ salt_settings.api_service }}
     - require:
       - service: {{ salt_settings.master_service }}


### PR DESCRIPTION
Without this change, the `salt.api` formula starts the service, but this configuration does not persist if the computer reboots.