### PR TITLE
Fixed pillar_roots generation for salt-master.

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -652,12 +652,12 @@ pillar_roots:
 {%- for dir in roots %}
     - {{ dir }}
 {%- endfor -%}
-{% endfor %}
-{%- elif 'pillar_roots' in cfg_salt -%}
+{%- endfor -%}
+{% elif 'pillar_roots' in cfg_salt -%}
 pillar_roots:
-{%- for name, roots in cfg_salt['pillar_roots']|dictsort -%}
+{%- for name, roots in cfg_salt['pillar_roots']|dictsort %}
   {{ name }}:
-{%- for dir in roots -%}
+{%- for dir in roots %}
     - {{ dir }}
 {%- endfor -%}
 {%- endfor -%}


### PR DESCRIPTION
With a simple pillar like this::

    $ sudo salt-call --config-dir /srv/etc/bootstrap --pillar-root /srv/pillar pillar.get salt:pillar_roots
    local:
        ----------
        base:
            - /srv/pillar

This was generated in /etc/salt/master.d/f_defaults.conf::

    # highstate format, and is generally just key/value pairs.
    pillar_roots:base:- /srv/pillar
    #

Resulting in parse errors by salt::

    $ sudo salt '*' state.highstate
    [ERROR   ] Error parsing configuration file: /etc/salt/master.d/f_defaults.conf - while scanning a simple key
      in "<string>", line 531, column 1:
        pillar_roots:base:- /srv/pillar
        ^
    could not found expected ':'
      in "<string>", line 532, column 1:
        #
        ^
    [ERROR   ] Error parsing configuration file: /etc/salt/master.d/f_defaults.conf - while scanning a simple key
      in "<string>", line 531, column 1:
        pillar_roots:base:- /srv/pillar
        ^
    could not found expected ':'
      in "<string>", line 532, column 1:
        #
        ^

This patch will fix it as such::

          ID: salt-master
    Function: file.recurse
        Name: /etc/salt/master.d
      Result: True
     Comment: Recursively updated /etc/salt/master.d
     Started: 11:37:12.946823
    Duration: 6255.296 ms
     Changes:
              ----------
              /etc/salt/master.d/f_defaults.conf:
                  ----------
                  diff:
                      ---
                      +++
                      @@ -528,7 +528,9 @@
                       # Pillar is laid out in the same fashion as the file server, with environments,
                       # a top file and sls files. However, pillar data does not need to be in the
                       # highstate format, and is generally just key/value pairs.
                      -pillar_roots:base:- /srv/pillar
                      +pillar_roots:
                      +  base:
                      +    - /srv/pillar
                       #

Resulting in::

    # highstate format, and is generally just key/value pairs.
    pillar_roots:
      base:
        - /srv/pillar
    #