### PR TITLE
Improve flexibility/quality of pygit2 state

### DIFF
--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -28,6 +28,13 @@ salt:
       install_from_source: True
     pygit2:
       install_from_source: True
+      version: 0.23.0
+      libgit2:
+        version: 0.23.0
+        install_from_source: True
+        build_parent_dir: /usr/src/
+        # hash necessary until github issue #9272 is addressed
+        download_hash: 683d1164e361e2a0a8d52652840e2340
     gitpython:
       install_from_source: False
 

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -9,22 +9,29 @@ Setup variable using grains['os_family'] based logic, only add key:values here
 that differ from whats in defaults.yaml
 ##}
 {% set os_family_map = salt['grains.filter_by']({
-    'Debian':  {},
-    'Ubuntu':  {},
-    'CentOS':  {},
-    'Amazon':  {},
-    'Fedora':  {},
+    'Debian':  {
+      'libgit2': 'libgit2-22',
+      'gitfs': {
+        'pygit2': {
+          'install_from_source': True,
+          'version': '0.22.1',
+          'libgit2': {
+            'install_from_source': False,
+          },
+        },
+      },
+    },
     'RedHat':  {
       'pygit2': 'python-pygit2',
       'gitfs': {
         'pygit2': {
-           'install_from_source': False
+           'install_from_source': False,
         },
       },
       'master': {
         'gitfs_provider': 'pygit2'
       },
-      'repotype': 'epel'
+      'repotype': 'epel',
     },
     'Suse':    {},
     'Gentoo':  {
@@ -32,7 +39,7 @@ that differ from whats in defaults.yaml
       'salt_minion': 'app-admin/salt',
       'salt_syndic': 'app-admin/salt',
       'salt_api': 'app-admin/salt',
-      'salt_cloud': 'app-admin/salt'
+      'salt_cloud': 'app-admin/salt',
     },
     'Arch':    {
       'salt_master': 'salt-zmq',
@@ -40,7 +47,7 @@ that differ from whats in defaults.yaml
       'salt_syndic':  'salt-zmq',
       'salt_cloud':  'salt-zmq',
       'salt_api': 'salt-zmq',
-      'salt_ssh':  'salt-zmq'
+      'salt_ssh':  'salt-zmq',
     },
     'FreeBSD': {
       'salt_master': 'py27-salt',
@@ -55,20 +62,17 @@ that differ from whats in defaults.yaml
       'minion_service': 'salt_minion',
       'master_service': 'salt_master',
       'api_service': 'salt_api',
-      'syndic_service': 'salt_syndic'
+      'syndic_service': 'salt_syndic',
     },
-  }
-  , grain="os_family"
-  , merge=salt['pillar.get']('salt:lookup'))
+  }, grain="os_family", merge=salt['pillar.get']('salt:lookup'))
 %}
 
 {## Merge the flavor_map to the default settings ##}
 {% do default_settings.salt.update(os_family_map) %}
-    
+
 {## Merge in salt:lookup pillar ##}
 {% set salt_settings = salt['pillar.get'](
     'salt',
     default=default_settings.salt,
-    merge=True
-  )
+    merge=True)
 %}


### PR DESCRIPTION
Added ability to specify version for pygit2 and libgit2 (when libgit2 is not provided by a package) via pillar. More importantly, leveraged this feature to make Debian-based distros install libgit2 via package instead of source.