### PR TITLE
Remove mapping test

### DIFF
--- a/salt/formulas.jinja
+++ b/salt/formulas.jinja
@@ -11,11 +11,7 @@
 {%- set value = salt['pillar.get']('salt_formulas:git_opts:{0}:{1}'.format(env, opt),
      salt['pillar.get']('salt_formulas:git_opts:default:{0}'.format(opt),
        defaults[opt])) -%}
-{%- if value is mapping -%}
 {{ value|yaml }}
-{%- else -%}
-{{ value }}
-{%- endif -%}
 {%- endmacro -%}
 
 {%- macro formulas_roots(env) -%}


### PR DESCRIPTION
This test isn't available in certain popular versions of Jinja (namely the one
installed by default in CentOS 6).