### PR TITLE
Fixed conflict with git-formula

### DIFF
--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -29,6 +29,10 @@ salt:
     pygit2:
       install_from_source: True
       version: 0.23.0
+      git:
+        # if not false, should be state name
+        require_state: False
+        install_from_package: git
       libgit2:
         version: 0.23.0
         install_from_source: True

--- a/salt/gitfs/pygit2.sls
+++ b/salt/gitfs/pygit2.sls
@@ -1,8 +1,14 @@
 {% from "salt/map.jinja" import salt_settings with context %}
 {% set pygit2_settings = salt_settings.gitfs.pygit2 %}
 
-git:
-  pkg.installed
+{% if pygit2_settings.git.get('require_state', False) %}
+include:
+  - {{ pygit2_settings.git.require_state }}
+{% elif pygit2_settings.git.get('install_from_package', 'git') %}
+pygit2-git:
+  pkg.installed:
+    - name: {{ pygit2_settings.git.install_from_package }}
+{% endif %}
 
 {% if pygit2_settings.install_from_source %}
 {% set libgit2_settings = pygit2_settings.libgit2 %}

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -15,6 +15,10 @@ that differ from whats in defaults.yaml
         'pygit2': {
           'install_from_source': True,
           'version': '0.22.1',
+          'git': {
+            'require_state': False,
+            'install_from_package': 'git',
+          },
           'libgit2': {
             'install_from_source': False,
           },
@@ -25,7 +29,11 @@ that differ from whats in defaults.yaml
       'pygit2': 'python-pygit2',
       'gitfs': {
         'pygit2': {
-           'install_from_source': False,
+          'install_from_source': False,
+          'git': {
+            'require_state': False,
+            'install_from_package': 'git',
+          },
         },
       },
       'master': {


### PR DESCRIPTION
pygit2 state installs git package using 'git' state ID, which is also used by the git-formula state. Changes in this PR permit delegation to another state for git dependency, or alternatively installs git with state ID of 'pygit2-git', to prevent ID conflicts.