### PR TITLE
Filter all calls to formulas_git_opt through load_yaml

### DIFF
--- a/salt/formulas.jinja
+++ b/salt/formulas.jinja
@@ -17,7 +17,8 @@
 {%- macro formulas_roots(env) -%}
 {%- set value = [] -%}
 {%- for dir in formulas.get(env, []) -%}
-{%- do value.append('{0}/{1}'.format(formulas_git_opt(env, 'basedir'), dir)) -%}
+{%- set basedir = formulas_git_opt(env, 'basedir')|load_yaml -%}
+{%- do value.append('{0}/{1}'.format(basedir, dir)) -%}
 {%- endfor -%}
 {{ value|yaml }}
 {%- endmacro -%}

--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -7,7 +7,7 @@
 {% for env, entries in salt['pillar.get']('salt_formulas:list', {}).iteritems() %}
 {% for entry in entries %}
 
-{% set basedir = formulas_git_opt(env, 'basedir') %}
+{% set basedir = formulas_git_opt(env, 'basedir')|load_yaml %}
 {% set gitdir = '{0}/{1}'.format(basedir, entry) %}
 {% set update = formulas_git_opt(env, 'update')|load_yaml %}
 
@@ -26,9 +26,10 @@
 {% if gitdir not in processed_gitdirs %}
 {% do processed_gitdirs.append(gitdir) %}
 {% set options = formulas_git_opt(env, 'options')|load_yaml %}
+{% set baseurl = formulas_git_opt(env, 'baseurl')|load_yaml %}
 {{ gitdir }}:
   git.latest:
-    - name: {{ formulas_git_opt(env, 'baseurl') }}/{{ entry }}.git
+    - name: {{ baseurl }}/{{ entry }}.git
     - target: {{ gitdir }}
     {%- for key, value in options.iteritems() %}
     - {{ key }}: {{ value }}


### PR DESCRIPTION
Jinja macros are not actually functions.  The only thing they can return
is a string.  In order to return structured data, the callee must
serialize it, and the caller must deserialize it.  This state formula
uses YAML as the intermediary, hence the occurrence of both the
`|yaml` (callee) and `|load_yaml` (caller) filters in its code.

The post-render "mapping values are not allowed here" error in
*salt/formulas.sls* or the broken rendering of
*salt/files/master.d/f_defaults.conf* happens because invocations of the
`formulas_git_opt` macro in several Jinja `set` statements do not get
deserialized, resulting in the trailing newline followed by three dot
characters (`...`), which YAML uses to signal the end of a document.
Correcting these rendering errors requires adding the necessary
deserialization code at those locations (i.e., filtering the macro call
through `|load_yaml`).

Closes #175.