### PR TITLE
Never fall back to `cfg_salt['master']` in minion config

### DIFF
--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -20,24 +20,13 @@
 {{ get_config('default_include', 'minion.d/*.conf') }}
 
 # master configs
-{%- if 'master' in cfg_minion -%}
-{%- if cfg_minion['master'] is not string %}
+{%- if 'master' in cfg_minion and cfg_minion['master'] is not string %}
 master:
   {% for name in cfg_minion['master'] -%}
   - {{ name }}
   {% endfor -%}
 {%- else %}
 {{ get_config('master', 'salt') }}
-{%- endif %}
-{% elif 'master' in cfg_salt -%}
-{%- if cfg_salt['master'] is not string %}
-master:
-  {% for name in cfg_salt['master'] -%}
-  - {{ name }}
-  {% endfor -%}
-{%- else %}
-{{ get_config('master', 'salt') }}
-{%- endif -%}
 {%- endif %}
 
 # choose a random master


### PR DESCRIPTION
if a special structure is required for master, it'll use whatever's defined in pillar.

Seems to resolve #178 