### PR TITLE
Manage show_jid option in master configuration

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -109,6 +109,9 @@
 # Return minions that timeout when running commands like test.ping
 {{ get_config('show_timeout', 'True') }}
 
+# Display the jid when a job is published
+{{ get_config('show_jid', 'False') }}
+
 # By default, output is colored. To disable colored output, set the color value
 # to False.
 {{ get_config('color', 'True') }}


### PR DESCRIPTION
This allows user to follow up on jobs a lot easier.