### PR TITLE
use salt_settings.syndic_service so state works on FreeBSD, too

### DIFF
--- a/salt/syndic.sls
+++ b/salt/syndic.sls
@@ -9,6 +9,7 @@ salt-syndic:
     - name: {{ salt_settings.salt_syndic }}
 {% endif %}
   service.running:
+    - name: {{ salt_settings.syndic_service }}
     - require:
       - service: salt-master
     - watch:


### PR DESCRIPTION
Previously:
```
----------
          ID: salt-syndic
    Function: service.running
      Result: False
     Comment: The named service salt-syndic is not available
     Started: 15:36:38.106414
    Duration: 28.398 ms
     Changes:   

Summary
------------
Succeeded: 5
Failed:    1
------------
```
With this additional line:
```
----------
          ID: salt-syndic
    Function: service.running
        Name: salt_syndic
      Result: True
     Comment: The service salt_syndic is already running
     Started: 15:40:58.786103
    Duration: 113.044 ms
     Changes:   

Summary
------------
Succeeded: 6
Failed:    0
------------
Total states run:     6
```
Tested on FreeBSD 10.2 and CentOS 6.7 with Salt 2015.5.x