### PR TITLE
Update salt.pkgrepo/Vagrant to use new APT repo on Ubuntu

### DIFF
--- a/dev/setup-salt.sh
+++ b/dev/setup-salt.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 sudo apt-get update -y
-sudo apt-get install python-software-properties pkg-config software-properties-common -y
-sudo add-apt-repository ppa:saltstack/salt -y
+echo 'deb http://repo.saltstack.com/apt/ubuntu/ubuntu14 trusty main' | sudo tee /etc/apt/sources.list.d/saltstack.list
+wget -O - https://repo.saltstack.com/apt/ubuntu/ubuntu14/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
+sudo apt-get update -y
 sudo apt-get install salt-master -y
 sudo apt-get install salt-minion -y
 # setup top files to test the formula

--- a/salt/pkgrepo/ubuntu/absent.sls
+++ b/salt/pkgrepo/ubuntu/absent.sls
@@ -1,3 +1,16 @@
-drop-saltstack-pkgrepo:
+drop-legacy-saltstack-pkgrepo:
   pkgrepo.absent:
     - ppa: saltstack/salt
+
+drop-saltstack-pkgrepo:
+  pkgrepo.absent:
+    {% if grains['osrelease'] == '14.04' %}
+    - dist: trusty
+    - key_url: https://repo.saltstack.com/apt/ubuntu/ubuntu14/SALTSTACK-GPG-KEY.pub
+    - name: deb http://repo.saltstack.com/apt/ubuntu/ubuntu14 trusty main
+    {% elif grains['osrelease'] == '12.04' %}
+    - dist: precise
+    - key_url: https://repo.saltstack.com/apt/ubuntu/ubuntu12/SALTSTACK-GPG-KEY.pub
+    - name: deb http://repo.saltstack.com/apt/ubuntu/ubuntu12 precise main
+    {% endif %}
+    - file: /etc/apt/sources.list.d/saltstack.list

--- a/salt/pkgrepo/ubuntu/init.sls
+++ b/salt/pkgrepo/ubuntu/init.sls
@@ -1,3 +1,16 @@
+legacy-saltstack-pkgrepo:
+  pkgrepo.absent:
+    - ppa: saltstack/salt
+
 saltstack-pkgrepo:
   pkgrepo.managed:
-    - ppa: saltstack/salt
+    {% if grains['osrelease'] == '14.04' %}
+    - dist: trusty
+    - key_url: https://repo.saltstack.com/apt/ubuntu/ubuntu14/SALTSTACK-GPG-KEY.pub
+    - name: deb http://repo.saltstack.com/apt/ubuntu/ubuntu14 trusty main
+    {% elif grains['osrelease'] == '12.04' %}
+    - dist: precise
+    - key_url: https://repo.saltstack.com/apt/ubuntu/ubuntu12/SALTSTACK-GPG-KEY.pub
+    - name: deb http://repo.saltstack.com/apt/ubuntu/ubuntu12 precise main
+    {% endif %}
+    - file: /etc/apt/sources.list.d/saltstack.list


### PR DESCRIPTION
Needed this for personal use. I'm very new to the SaltStack ecosystem - if there are more idiomatic ways to approach this, or a means of testing that I overlooked, I'm happy to update this PR as desired.