### PR TITLE
Make Debian use pkgrepo.managed

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -4,12 +4,14 @@
 {## Start with  defaults from defaults.yaml ##}
 {% import_yaml "salt/defaults.yaml" as default_settings %}
 
-{## 
+{##
 Setup variable using grains['os_family'] based logic, only add key:values here
 that differ from whats in defaults.yaml
 ##}
 {% set os_family_map = salt['grains.filter_by']({
     'Debian':  {
+      'pkgrepo': 'deb http://debian.saltstack.com/debian ' + salt['grains.get']('oscodename') + '-saltstack main',
+      'key_url': 'salt://' + slspath + '/saltstack.gpg',
       'libgit2': 'libgit2-22',
       'gitfs': {
         'pygit2': {

--- a/salt/pkgrepo/debian/absent.sls
+++ b/salt/pkgrepo/debian/absent.sls
@@ -1,4 +1,8 @@
+{% from "salt/map.jinja" import salt_settings with context %}
+
 drop-saltstack-pkgrepo:
+  pkgrepo.absent:
+    - name: {{ salt_settings.pkgrepo }}
   file.absent:
     - name: /etc/apt/sources.list.d/saltstack.list
 

--- a/salt/pkgrepo/debian/init.sls
+++ b/salt/pkgrepo/debian/init.sls
@@ -1,21 +1,11 @@
-saltstack-apt-key:
-  file.managed:
-    - name: /etc/apt/trusted.gpg.d/saltstack.gpg
-    - source: salt://{{ slspath }}/saltstack.gpg
-    - user: root
-    - group: root
-    - mode: 644
+{% from "salt/map.jinja" import salt_settings with context %}
 
 saltstack-pkgrepo:
-  file.managed:
-    - name: /etc/apt/sources.list.d/saltstack.list
-    - source: salt://{{ slspath }}/sources.list
-    - user: root
-    - group: root
-    - mode: 644
-    - template: jinja
-    - require:
-      - file: saltstack-apt-key
+  pkgrepo.managed:
+    - humanname: SaltStack Debian Repo
+    - name: {{ salt_settings.pkgrepo }}
+    - file: /etc/apt/sources.list.d/saltstack.list
+    - key_url: {{ salt_settings.key_url }}
     # Order: 1 because we can't put a require_in on "pkg: salt-{master,minion}"
     # because we don't know if they are used.
     - order: 1

--- a/salt/pkgrepo/debian/sources.list
+++ b/salt/pkgrepo/debian/sources.list
@@ -1,2 +1,0 @@
-# saltstack
-deb http://debian.saltstack.com/debian {{ grains['oscodename'] }}-saltstack main


### PR DESCRIPTION
…and allow the repo name and key_url to be overridden via Pillar lookup. I've created this so I can switch over to repo.saltstack.com but hopefully kept the formula backward-compatible.