### PR TITLE
Add clean_file to wipe saltstack.list contents

### DIFF
--- a/salt/pkgrepo/debian/init.sls
+++ b/salt/pkgrepo/debian/init.sls
@@ -6,6 +6,7 @@ saltstack-pkgrepo:
     - name: {{ salt_settings.pkgrepo }}
     - file: /etc/apt/sources.list.d/saltstack.list
     - key_url: {{ salt_settings.key_url }}
+    - clean_file: True
     # Order: 1 because we can't put a require_in on "pkg: salt-{master,minion}"
     # because we don't know if they are used.
     - order: 1


### PR DESCRIPTION
The clean_file parameter is ignored on versions before 2015.8 but is useful.