### PR TITLE
Dropped ppa and updated to official repos for ubuntu

### DIFF
--- a/salt/pkgrepo/ubuntu/absent.sls
+++ b/salt/pkgrepo/ubuntu/absent.sls
@@ -1,3 +1,5 @@
 drop-saltstack-pkgrepo:
   pkgrepo.absent:
-    - ppa: saltstack/salt
+    - name: deb http://repo.saltstack.com/apt/ubuntu/{{ grains['lsb_distrib_release'] }}/amd64/latest {{ grains['lsb_distrib_codename'] }} main
+    - file: /etc/apt/sources.list.d/saltstack.list
+    - key_url: https://repo.saltstack.com/apt/ubuntu/{{ grains['lsb_distrib_release'] }}/amd64/latest/SALTSTACK-GPG-KEY.pub

--- a/salt/pkgrepo/ubuntu/init.sls
+++ b/salt/pkgrepo/ubuntu/init.sls
@@ -1,3 +1,5 @@
 saltstack-pkgrepo:
   pkgrepo.managed:
-    - ppa: saltstack/salt
+    - name: deb http://repo.saltstack.com/apt/ubuntu/{{ grains['lsb_distrib_release'] }}/amd64/latest {{ grains['lsb_distrib_codename'] }} main
+    - file: /etc/apt/sources.list.d/saltstack.list
+    - key_url: https://repo.saltstack.com/apt/ubuntu/{{ grains['lsb_distrib_release'] }}/amd64/latest/SALTSTACK-GPG-KEY.pub


### PR DESCRIPTION
It seems that Ubuntu's PPA's are currently out of date and no longer maintained (newest release is 2015.5.3).  This change allows adding the official SaltStack PPA's