### PR TITLE
Support for downloading formulas from multiple baseurls into same environment

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -160,9 +160,11 @@ salt_formulas:
   # List of formulas to enable in each environment
   list:
     base:
-      - salt-formula
-      - postfix-formula
+      https://github.com/saltstack-formulas:
+        - salt-formula
+        - postfix-formula
     dev:
-      - salt-formula
-      - postfix-formula
-      - openssh-formula
+      https://github.com/saltstack-formulas
+        - salt-formula
+        - postfix-formula
+        - openssh-formula

--- a/pillar.example
+++ b/pillar.example
@@ -135,9 +135,6 @@ salt_formulas:
     # environment, if an option is missing in a given environment, the
     # value from "default" is used instead.
     default:
-      # URL where the formulas git repositories are downloaded from
-      # it will be suffixed with <formula-name>.git
-      baseurl: https://github.com/saltstack-formulas
       # Directory where Git repositories are downloaded
       basedir: /srv/formulas
       # Update the git repository to the latest version (False by default)
@@ -164,7 +161,7 @@ salt_formulas:
         - salt-formula
         - postfix-formula
     dev:
-      https://github.com/saltstack-formulas
+      https://github.com/saltstack-formulas:
         - salt-formula
         - postfix-formula
         - openssh-formula

--- a/salt/formulas.jinja
+++ b/salt/formulas.jinja
@@ -16,9 +16,11 @@
 
 {%- macro formulas_roots(env) -%}
 {%- set value = [] -%}
-{%- for dir in formulas.get(env, []) -%}
+{%- for repo,f_name in formulas.get(env, {}).items() -%}
+{%- for dir in f_name -%}
 {%- set basedir = formulas_git_opt(env, 'basedir')|load_yaml -%}
 {%- do value.append('{0}/{1}'.format(basedir, dir)) -%}
+{%- endfor -%}
 {%- endfor -%}
 {{ value|yaml }}
 {%- endmacro -%}

--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -4,7 +4,8 @@
 {% from "salt/formulas.jinja" import formulas_git_opt with context %}
 
 # Loop over all formulas listed in pillar data
-{% for env, entries in salt['pillar.get']('salt_formulas:list', {}).items() %}
+{% for env, elements in salt['pillar.get']('salt_formulas:list', {}).items() %}
+{% for baseurl, entries in elements.items() %}
 {% for entry in entries %}
 
 {% set basedir = formulas_git_opt(env, 'basedir')|load_yaml %}
@@ -26,7 +27,6 @@
 {% if gitdir not in processed_gitdirs %}
 {% do processed_gitdirs.append(gitdir) %}
 {% set options = formulas_git_opt(env, 'options')|load_yaml %}
-{% set baseurl = formulas_git_opt(env, 'baseurl')|load_yaml %}
 {{ gitdir }}:
   git.latest:
     - name: {{ baseurl }}/{{ entry }}.git
@@ -41,5 +41,6 @@
     {%- endif %}
 {% endif %}
 
+{% endfor %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Currently the `baseurl` specified for downloading formulas using the `formula.sls` state is aligned with a specific environment. This means, that you cannot download formulas from different URLs into the *same* environment, however you can create a new environment using a different `baseurl`.

This creates a significant restriction on the ability to construct an environment that will source formulas from a variety of sources.

This pull request adds the ability to specify multiple URLs for a single environment.

Couple of notes:

* It adds some complexity to the pillar, where a `baseurl` *must* be specified for each environment
* It (probably more importantly) breaks backwards compatibility with earlier versions. This could probably be resolved by using the *default* `baseurl` specified in the `git_opts`