### PR TITLE
install python-tornado package in case rest_tornado is used

### DIFF
--- a/salt/api.sls
+++ b/salt/api.sls
@@ -6,7 +6,11 @@ include:
 salt-api:
 {% if salt_settings.install_packages %}
   pkg.installed:
-    - name: {{ salt_settings.salt_api }}
+    - pkgs:
+      - {{ salt_settings.salt_api }}
+{% if salt['pillar.get']('salt:master:rest_tornado', {}) %}
+      - {{ salt_settings.python_tornado }}
+{% endif %}
 {% endif %}
   service.running:
     - enable: True

--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -17,6 +17,7 @@ salt:
   salt_cloud: salt-cloud
   salt_api: salt-api
   salt_ssh: salt-ssh
+  python_tornado: python-tornado
 
   python_git: python-git
 


### PR DESCRIPTION
python-tornado is installed as package, which works fine on Fedora. The package name is fine for RHEL and Debian based systems.