### PR TITLE
Allow nesting commands under minion names in master ACL config

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -323,11 +323,9 @@ event_return_blacklist:
 # disabled.
 {% if 'client_acl' in cfg_master -%}
 client_acl:
-{%- for name, user in cfg_master['client_acl']|dictsort %}
+{%- for name, items in cfg_master['client_acl']|dictsort %}
   {{ name}}:
-{%- for command in user %}
-    - {% raw %}'{% endraw %}{{ command }}{% raw %}'{% endraw %}
-{%- endfor -%}
+    {{ items | yaml }}
 {%- endfor -%}
 {% elif 'client_acl' in cfg_salt -%}
 client_acl:


### PR DESCRIPTION
The current code allows ACL's like:-

```yaml
client_acl:
  # Allow thatch to execute anything.
  thatch:
    - .*
```

But it breaks horribly on ACL's like:-

```yaml
client_acl:
  # Allow fred to use test and pkg, but only on "web*" minions.
  fred:
    - web*:
      - test.*
      - pkg.*
```

This patch fixes this - perhaps not in the safest or most elegant way, but it seems to work.