### PR TITLE
Add Windows support to map.jinja

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -74,6 +74,11 @@ that differ from whats in defaults.yaml
       'api_service': 'salt_api',
       'syndic_service': 'salt_syndic',
     },
+    'Windows': {
+      'salt_minion': 'saltstack.minion',
+      'config_path': 'C:\salt\conf',
+      'minion_service': 'salt-minion',
+    },
   }, grain="os_family", merge=salt['pillar.get']('salt:lookup'))
 %}
 


### PR DESCRIPTION
This adds some minimal support for Windows minions.