### PR TITLE
Take mine_functions back

### DIFF
--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -204,6 +204,14 @@ id: {{ cfg_minion['id'] }}
 # Ping Master to ensure connection is alive (minutes).
 {{ get_config('ping_interval', '0') }}
 
+{%- if 'mine_functions' in cfg_minion %}
+mine_functions:
+{%- for func, args in cfg_minion['mine_functions'].items() %}
+  {{ func }}: {{ args }}
+{%- endfor %}
+{%- endif %}
+
+
 # To auto recover minions if master changes IP address (DDNS)
 #    auth_tries: 10
 #    auth_safemode: False


### PR DESCRIPTION
After merging #204 ``mine_functions`` was accidently removed. I say accidentaly because it's still in pillar.example. I suppose it should be taken back in order to maintain backwards compatibilty.