### PR TITLE
Prefix configuration files with the suitable O/S-specific pathname

### DIFF
--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -36,7 +36,7 @@ salt-cloud:
 {% for type in ['pem'] %}
 cloud-cert-{{ cert }}-pem:
   file.managed:
-    - name: /etc/salt/pki/cloud/{{ cert }}.pem
+    - name: {{ salt_settings.config_path }}/pki/cloud/{{ cert }}.pem
     - source: salt://{{ slspath }}/files/key
     - template: jinja
     - user: root
@@ -52,7 +52,7 @@ cloud-cert-{{ cert }}-pem:
 {%- for dir, templ_path in salt_settings.cloud.template_sources.items() %}
 salt-cloud-{{ dir }}:
   file.recurse:
-    - name: /etc/salt/cloud.{{ dir }}.d
+    - name: {{ salt_settings.config_path }}/cloud.{{ dir }}.d
     - source: {{ templ_path }}
     - template: jinja
     - makedirs: True
@@ -60,7 +60,7 @@ salt-cloud-{{ dir }}:
 
 salt-cloud-providers-permissions:
   file.directory:
-    - name: /etc/salt/cloud.providers.d
+    - name: {{ salt_settings.config_path }}/cloud.providers.d
     - user: root
     - group: root
     - file_mode: 600

--- a/salt/files/cloud.providers.d/ec2.conf
+++ b/salt/files/cloud.providers.d/ec2.conf
@@ -1,6 +1,7 @@
 # This file managed by Salt, do not edit by hand!!
-{% set cloud = salt['pillar.get']('salt:cloud', {}) -%}
-{% if 'aws_key' in cloud %}
+{%- from "salt/map.jinja" import salt_settings with context -%}
+{%- set cloud = salt['pillar.get']('salt:cloud', {}) -%}
+{%- if 'aws_key' in cloud %}
 ec2_ubuntu_public:
   minion:
     master: {{ cloud.get('master', 'salt') }}
@@ -9,10 +10,10 @@ ec2_ubuntu_public:
   ssh_interface: public_ips
   id: {{ cloud.get('aws_key', 'DEFAULT') }}
   key: '{{ cloud.get('aws_secret', 'DEFAULT') }}'
-  private_key: /etc/salt/pki/cloud/ec2.pem
+  private_key: {{ salt_settings.config_path }}/pki/cloud/ec2.pem
   keyname: keyname
   location: eu-west-1
   availability_zone: eu-west-1a
   ssh_username: ubuntu
   provider: ec2
-{% endif %}
+{%- endif %}

--- a/salt/files/cloud.providers.d/gce.conf
+++ b/salt/files/cloud.providers.d/gce.conf
@@ -1,10 +1,11 @@
 # This file managed by Salt, do not edit by hand!!
+{%- from "salt/map.jinja" import salt_settings with context -%}
 {%- set cloud = salt['pillar.get']('salt:cloud', {}) -%}
 {%- if 'gce_project' in cloud %}
 gce:
   project: "{{ cloud.get('gce_project', 'DEFAULT') }}"
   service_account_email_address: "{{ cloud.get('gce_service_account_email_address', 'DEFAULT') }}"
-  service_account_private_key: "/etc/salt/pki/cloud/gce.pem"
+  service_account_private_key: "{{ salt_settings.config_path }}/pki/cloud/gce.pem"
   minion:
     master: {{ cloud.get('master', 'salt') }}
   grains:

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -11,7 +11,7 @@ that differ from whats in defaults.yaml
 {% set os_family_map = salt['grains.filter_by']({
     'Debian':  {
       'pkgrepo': 'deb http://debian.saltstack.com/debian ' + salt['grains.get']('oscodename') + '-saltstack main',
-      'key_url': 'salt://' + slspath + '/saltstack.gpg',
+      'key_url': 'salt://salt/pkgrepo/debian/saltstack.gpg',
       'libgit2': 'libgit2-22',
       'gitfs': {
         'pygit2': {

--- a/salt/master.sls
+++ b/salt/master.sls
@@ -24,4 +24,4 @@ salt-master:
 # clean up old _defaults.conf file if they have it around
 remove-old-master-conf-file:
   file.absent:
-    - name: /etc/salt/master.d/_defaults.conf
+    - name: {{ salt_settings.config_path }}/master.d/_defaults.conf

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -26,4 +26,4 @@ salt-minion:
 # clean up old _defaults.conf file if they have it around
 remove-old-minion-conf-file:
   file.absent:
-    - name: /etc/salt/minion.d/_defaults.conf
+    - name: {{ salt_settings.config_path }}/minion.d/_defaults.conf

--- a/salt/standalone.sls
+++ b/salt/standalone.sls
@@ -25,4 +25,4 @@ salt-minion:
 # clean up old _defaults.conf file if they have it around
 remove-old-standalone-conf-file:
   file.absent:
-    - name: /etc/salt/minion.d/_defaults.conf
+    - name: {{ salt_settings.config_path }}/minion.d/_defaults.conf


### PR DESCRIPTION
Operating systems such as FreeBSD install the salt configuration files in locations other than `/etc/salt`.  The changes in this PR replace existing references to that location with the `config_path` variable, which gets overridden in *map.jinja* as appropriate.