### PR TITLE
Renamed "provider" to "driver"

### DIFF
--- a/salt/files/cloud.providers.d/ec2.conf
+++ b/salt/files/cloud.providers.d/ec2.conf
@@ -15,5 +15,5 @@ ec2_ubuntu_public:
   location: eu-west-1
   availability_zone: eu-west-1a
   ssh_username: ubuntu
-  provider: ec2
+  driver: ec2
 {%- endif %}

--- a/salt/files/cloud.providers.d/gce.conf
+++ b/salt/files/cloud.providers.d/gce.conf
@@ -10,5 +10,5 @@ gce:
     master: {{ cloud.get('master', 'salt') }}
   grains:
     test: True
-  provider: gce
+  driver: gce
 {%- endif %}

--- a/salt/files/cloud.providers.d/rsos.conf
+++ b/salt/files/cloud.providers.d/rsos.conf
@@ -14,7 +14,7 @@ rsos_{{ region|lower }}:
   compute_name: cloudServersOpenStack
   protocol: ipv4
   compute_region: {{ region }}
-  provider: openstack
+  driver: openstack
   user:  {{ cloud.get('rsos_user', 'DEFAULT') }}
   tenant: {{ cloud.get('rsos_tenant', 'DEFAULT') }}
   apikey: {{ cloud.get('rsos_apikey', 'DEFAULT') }}

--- a/salt/files/cloud.providers.d/saltify.conf
+++ b/salt/files/cloud.providers.d/saltify.conf
@@ -3,6 +3,6 @@
 {% set cloud = salt['pillar.get']('salt:cloud', {}) -%}
 
 saltify:
-  provider: saltify
+  driver: saltify
   minion:
     master: {{ cloud.get('master', 'salt') }}


### PR DESCRIPTION
On 2015.8.8 I get the following warning:

```
/usr/lib/python2.7/dist-packages/salt/config.py:2346: DeprecationWarning: The term 'provider' is being deprecated in favor of 'driver'. Support for 'provider' will be removed in Salt Nitrogen. Please convert your cloud provider configuration files to use 'driver'.
```

This PR renames "provider" to "driver".