### PR TITLE
Comment out second master config example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -45,9 +45,9 @@ salt:
     master: salt
 
     # multi master setup
-    master:
-      - salt_master_1
-      - salt_master_2
+    #master:
+      #- salt_master_1
+      #- salt_master_2
 
     fileserver_backend:
       - git


### PR DESCRIPTION
This second master config example was causing problems when vagrant
would use the default pillar.example

Fixes #217