### PR TITLE
Use the latest stable salt from repo.saltstack.com

### DIFF
--- a/dev/setup-salt.sh
+++ b/dev/setup-salt.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
+
+# use the latest stable Salt from repo.saltstack.com
+wget -O - https://repo.saltstack.com/apt/ubuntu/14.04/amd64/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
+sudo echo 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/latest trusty main' > /etc/apt/sources.list.d/saltstack.list
+
 sudo apt-get update -y
-sudo apt-get install python-software-properties pkg-config software-properties-common -y
-sudo add-apt-repository ppa:saltstack/salt -y
 sudo apt-get install salt-master -y
 sudo apt-get install salt-minion -y
 # setup top files to test the formula


### PR DESCRIPTION
The old ppa was being used, which was causing Salt 0.17.5 to be installed. Yuck.