### PR TITLE
Install latest stable version of Salt

### DIFF
--- a/dev/setup-salt.sh
+++ b/dev/setup-salt.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 sudo apt-get update -y
 sudo apt-get install python-software-properties pkg-config software-properties-common -y
-sudo add-apt-repository ppa:saltstack/salt -y
+curl -L https://bootstrap.saltstack.com -o install_salt.sh
+sudo sh ./install_salt.sh
 sudo apt-get install salt-master -y
 sudo apt-get install salt-minion -y
 # setup top files to test the formula

--- a/pillar.truefitness
+++ b/pillar.truefitness
@@ -1,0 +1,168 @@
+salt:
+  # Set this to true to clean any non-salt-formula managed files out of
+  # /etc/salt/{master,minion}.d ... You really don't want to do this on 2015.2
+  # and up as it'll wipe out important files that Salt relies on.
+  clean_config_d_dir: False
+
+  # Set this to False to not have the formula install packages (in the case you
+  # install Salt via git/pip/etc.)
+  install_packages: True
+
+  # to overwrite map.jinja salt packages
+  lookup:
+    salt-master: 'salt-master'
+    salt-minion: 'salt-minion'
+    salt-syndic: 'salt-syndic'
+    salt-cloud: 'salt-cloud'
+    salt-ssh: 'salt-ssh'
+
+  # salt master config
+  master:
+    fileserver_backend:
+      - git
+      - roots
+    gitfs_remotes:
+      - git://github.com/saltstack-formulas/salt-formula.git:
+        - base: develop
+    file_roots:
+      base:
+        - /srv/salt
+    pillar_roots:
+      base:
+        - /srv/pillar
+    # for salt-api with tornado rest interface
+    rest_tornado:
+      port: 8000
+      ssl_crt: /etc/pki/api/certs/server.crt
+      ssl_key: /etc/pki/api/certs/server.key
+      debug: False
+      disable_ssl: False
+
+  # salt minion config:
+  minion:
+
+    # single master setup
+    master: salt
+
+    # multi master setup
+    #master:
+      #- salt_master_1
+      #- salt_master_2
+
+    fileserver_backend:
+      - git
+      - roots
+    gitfs_remotes:
+      - git://github.com/saltstack-formulas/salt-formula.git:
+        - base: develop
+    file_roots:
+      base:
+        - /srv/salt
+    pillar_roots:
+      base:
+        - /srv/pillar
+    module_config:
+      test: True
+      test.foo: foo
+      test.bar:
+        - baz
+        - quo
+      test.baz:
+        spam: sausage
+        cheese: bread
+
+    # salt mine setup
+    mine_interval: 60
+    # mine_functions can be set at the top level of the pillar, and
+    # that is preferable because it doesn't affect the conf file and
+    # doesn't require a minion restart. However, you can configure it
+    # here instead if you really want to.
+    mine_functions:
+      network.interface_ip: [eth0]
+
+  # salt cloud config
+  cloud:
+    master: salt
+
+    # You can take profile and map templates from an alternate location
+    # if you want to write your own.
+    template_sources:
+      providers: salt://salt/files/cloud.providers.d
+      profiles: salt://salt/files/cloud.profiles.d
+      maps: salt://salt/files/cloud.maps.d
+
+    # These settings are used by the default provider templates and
+    # only need to be set for the ones you're using.
+    aws_key: AWSKEYIJSHJAIJS6JSH
+    aws_secret: AWSSECRETYkkDY1iQf9zRtl9+pW+Nm+aZY95
+    gce_project: test
+    gce_service_account_email_address: 867543072364-orl4h2tpp8jcn1tr9ipj@developer.gserviceaccount.com
+    rsos_user: afeawofghob
+    rsos_tenant: tenant_id_number
+    rsos_apikey: WFJIOJEOIGHSOFHESO
+    rsos_regions:
+      - ORD
+      - DFW
+      - IAD
+      - SYD
+      - HKG
+  reactor:
+    - 'deploy':
+      - /srv/salt/reactors/deploy.sls
+  ssh_roster:
+    prod1:
+      host: host.example.com
+      user: ubuntu
+      sudo: True
+      priv: /etc/salt/ssh_keys/sshkey.pem
+
+salt_cloud_certs:
+  aws:
+    pem: |
+      -----BEGIN RSA PRIVATE KEY-----
+      ...........
+      -----END RSA PRIVATE KEY-----
+
+  gce:
+    pem: |
+      -----BEGIN RSA PRIVATE KEY-----
+      ...........
+      -----END RSA PRIVATE KEY-----
+
+salt_formulas:
+  git_opts:
+    # The Git options can be customized differently for each
+    # environment, if an option is missing in a given environment, the
+    # value from "default" is used instead.
+    default:
+      # URL where the formulas git repositories are downloaded from
+      # it will be suffixed with <formula-name>.git
+      baseurl: https://github.com/saltstack-formulas
+      # Directory where Git repositories are downloaded
+      basedir: /srv/formulas
+      # Update the git repository to the latest version (False by default)
+      update: False
+      # Options passed directly to the git.latest state
+      options:
+        rev: master
+    dev:
+      basedir: /srv/formulas/dev
+      update: True
+      options:
+        rev: develop
+  # Options of the file.directory state that creates the directory where
+  # the git repositories of the formulas are stored
+  basedir_opts:
+    makedirs: True
+    user: root
+    group: root
+    mode: 755
+  # List of formulas to enable in each environment
+  list:
+    base:
+      - salt-formula
+      - postfix-formula
+    dev:
+      - salt-formula
+      - postfix-formula
+      - openssh-formula


### PR DESCRIPTION
Use the salt bootstrap method to install salt.  The current method yields old versions of salt:

```
sudo salt '*' test.versions_report
salt:
               Salt: 0.17.5
             Python: 2.7.6 (default, Jun 22 2015, 17:58:13)
             Jinja2: 2.7.2
           M2Crypto: 0.21.1
     msgpack-python: 0.3.0
       msgpack-pure: Not Installed
           pycrypto: 2.6.1
             PyYAML: 3.10
              PyZMQ: 14.0.1
                ZMQ: 4.0.4

```
With this change in places, the resulting versions are:

> salt:
>     Salt Version:
>                Salt: 2015.8.8.2
>      
>     Dependency Versions:
>              Jinja2: 2.7.2
>            M2Crypto: Not Installed
>                Mako: 0.9.1
>              PyYAML: 3.10
>               PyZMQ: 14.0.1
>              Python: 2.7.6 (default, Jun 22 2015, 17:58:13)
>                RAET: Not Installed
>             Tornado: 4.2.1
>                 ZMQ: 4.0.4
>                cffi: Not Installed
>            cherrypy: Not Installed
>            dateutil: 1.5
>               gitdb: 0.5.4
>           gitpython: 0.3.2 RC1
>               ioflo: Not Installed
>             libgit2: Not Installed
>             libnacl: Not Installed
>        msgpack-pure: Not Installed
>      msgpack-python: 0.3.0
>        mysql-python: 1.2.3
>           pycparser: Not Installed
>            pycrypto: 2.6.1
>              pygit2: Not Installed
> 
>         PyZMQ: 14.0.1
>              Python: 2.7.6 (default, Jun 22 2015, 17:58:13)
>                RAET: Not Installed
>             Tornado: 4.2.1
>                 ZMQ: 4.0.4
>                cffi: Not Installed
>            cherrypy: Not Installed
>            dateutil: 1.5
>               gitdb: 0.5.4
>           gitpython: 0.3.2 RC1
>               ioflo: Not Installed
>             libgit2: Not Installed
>             libnacl: Not Installed
>        msgpack-pure: Not Installed
>      msgpack-python: 0.3.0
>        mysql-python: 1.2.3
>           pycparser: Not Installed
>            pycrypto: 2.6.1
>              pygit2: Not Installed
>        python-gnupg: Not Installed
>               smmap: 0.8.2
>             timelib: Not Installed
>        System Versions:
>                dist: Ubuntu 14.04 trusty
>             machine: x86_64
>             release: 3.13.0-83-generic
>              system: Ubuntu 14.04 trusty
> 