### PR TITLE
jinja convert abspath URIs to relapath for _root and _mountpoint gitfs support

### DIFF
--- a/salt/api.sls
+++ b/salt/api.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath + "/map.jinja" import salt_settings with context %}
 
 include:
   - salt.master

--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath + "/map.jinja" import salt_settings with context %}
 
 python-pip:
   pkg.installed

--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -12,7 +12,7 @@
 #{{ configname }}: {{ default_value }}
 {%- endif -%}
 {%- endmacro -%}
-{%- from 'salt/formulas.jinja' import file_roots, formulas with context -%}
+{%- from uri_formulas_jinja import file_roots, formulas with context -%}
 ##### Primary configuration settings #####
 ##########################################
 # This configuration file is used to manage the behavior of the Salt Master.

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -13,7 +13,7 @@
 #{{ configname }}: {{ default_value }}
 {%- endif -%}
 {%- endmacro -%}
-{%- from 'salt/formulas.jinja' import file_roots, formulas with context -%}
+{%- from  uri_formulas_jinja import file_roots, formulas with context -%}
 
 ##### Primary configuration settings #####
 ##########################################

--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -1,7 +1,7 @@
 {% set processed_gitdirs = [] %}
 {% set processed_basedirs = [] %}
 
-{% from "salt/formulas.jinja" import formulas_git_opt with context %}
+{% from slspath + "/formulas.jinja" import formulas_git_opt with context %}
 
 # Loop over all formulas listed in pillar data
 {% for env, entries in salt['pillar.get']('salt_formulas:list', {}).items() %}

--- a/salt/gitfs/dulwich.sls
+++ b/salt/gitfs/dulwich.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath.split('/')[:-1] + "/map.jinja" import salt_settings with context %}
 # issue 34
 
 {% if salt_settings.gitfs.dulwich.install_from_source %}

--- a/salt/gitfs/gitpython.sls
+++ b/salt/gitfs/gitpython.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath.split('/')[:-1] + "/map.jinja" import salt_settings with context %}
 
 {% if salt_settings.gitfs.gitpython.install_from_source %}
 

--- a/salt/gitfs/pygit2.sls
+++ b/salt/gitfs/pygit2.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath.split('/')[:-1] + "/map.jinja" import salt_settings with context %}
 {% set pygit2_settings = salt_settings.gitfs.pygit2 %}
 
 {% if pygit2_settings.git.get('require_state', False) %}

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -2,7 +2,7 @@
 # vim: ft=jinja
 
 {## Start with  defaults from defaults.yaml ##}
-{% import_yaml "salt/defaults.yaml" as default_settings %}
+{% import_yaml slspath + "/defaults.yaml" as default_settings %}
 
 {##
 Setup variable using grains['os_family'] based logic, only add key:values here

--- a/salt/master.sls
+++ b/salt/master.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath + "/map.jinja" import salt_settings with context %}
 
 salt-master:
 {% if salt_settings.install_packages %}
@@ -11,6 +11,8 @@ salt-master:
     - source: salt://{{ slspath }}/files/master.d
     - clean: {{ salt_settings.clean_config_d_dir }}
     - exclude_pat: _*
+    - defaults:
+        uri_formulas: {{ slspath + "/formulas.jinja" }}
   service.running:
     - enable: True
     - name: {{ salt_settings.master_service }}

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath + "/map.jinja" import salt_settings with context %}
 
 salt-minion:
 {% if salt_settings.install_packages %}

--- a/salt/pkgrepo/debian/absent.sls
+++ b/salt/pkgrepo/debian/absent.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath.split('/')[:-1] + "/map.jinja" import salt_settings with context %}
 
 drop-saltstack-pkgrepo:
   pkgrepo.absent:

--- a/salt/pkgrepo/debian/init.sls
+++ b/salt/pkgrepo/debian/init.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath.split('/')[:-1] + "/map.jinja" import salt_settings with context %}
 
 saltstack-pkgrepo:
   pkgrepo.managed:

--- a/salt/pkgrepo/redhat/init.sls
+++ b/salt/pkgrepo/redhat/init.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath.splt('/')[:-1] + "/map.jinja" import salt_settings with context %}
 
 saltstack-pkgrepo:
   pkgrepo.managed:

--- a/salt/ssh.sls
+++ b/salt/ssh.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath + "/map.jinja" import salt_settings with context %}
 
 {% if salt_settings.install_packages %}
 ensure-salt-ssh-is-installed:

--- a/salt/standalone.sls
+++ b/salt/standalone.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath + "/map.jinja" import salt_settings with context %}
 
 salt-minion:
 {% if salt_settings.install_packages %}

--- a/salt/syndic.sls
+++ b/salt/syndic.sls
@@ -1,4 +1,4 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+{% from slspath + "/map.jinja" import salt_settings with context %}
 
 include:
   - salt.master


### PR DESCRIPTION
PROBLEM: 
  - I found this formula very useful, but wanted to control how it was added to my roots tree. 
  - In particular, only the ./salt dir in the formula will be added, and it will be placed in my roots tree at salt://formula/salt-formula .
  - This is achievable using a combination of gitfs_root and gitfs_mountpoint options, but when I tried this I discovered breaks in the formula-internal URIs. 

SOLUTION:
  - I feel this is an unnecessary and inadvertent constraint, so set about fixing/removing it by replacing static paths within the formula with jinja fashioned to produce dynamic internal reference with the effect of relative symlinks.
  - For formulae in particular I think repo-internal URIs should maintain internal coherence regardless of placement within a state tree as this is important for freedom of use and predictable ease of use.

CAVEAT:
  - I originally did this work starting from https://github.com/saltstack-formulas/salt-formula/commit/7abdf217a99d70344b6d936375e802837276a2a3 to (successfully) scratch my own itch with the intention of cleaning it up and pushing upstream. 
  - Since then some effort has gone into addressing the same problem space, so I wanted to contribute my favored approach.
  - I'm not especially familiar with the process or culture around PRs, but hope this is deemed acceptable. It's worthwhile to me to correct any problems found, so freely let me know if it can be improved.




Many thanks!

