### PR TITLE
Ability to create non-templated cloud maps/providers/profiles

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -83,6 +83,37 @@ salt:
   # salt cloud config
   cloud:
     master: salt
+    
+    # For non-templated custom cloud provider/profile/map files
+    providers:
+      provider-filename1.conf:
+        vmware-prod:
+          driver: vmware
+          user: myusernameprod
+          password: mypassword
+        vmware-nonprod:
+          driver: vmware
+          user: myusernamenonprod
+          password: mypassword
+    profiles:
+      profile-filename1.conf:
+        server-non-prod:
+          clonefrom: rhel6xtemplatenp
+          grains:
+            platform:
+              name: salt
+              realm: lab
+            subscription_level: standard
+          memory: 8GB
+          num_cpus: 4
+          password: sUpErsecretey
+          provider: vmware-nonprod
+    maps:
+      map-filename1.map:
+        server-non-prod:
+          - host.mycompany.com:
+              grains: 
+                environment: dev1
 
     # You can take profile and map templates from an alternate location
     # if you want to write your own.

--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -1,5 +1,9 @@
 {% from "salt/map.jinja" import salt_settings with context %}
 
+{% set cloudmaps = salt['pillar.get']('salt:cloud:maps', {}) -%}
+{% set cloudprofiles = salt['pillar.get']('salt:cloud:profiles', {}) -%}
+{% set cloudproviders = salt['pillar.get']('salt:cloud:providers', {}) -%}
+
 python-pip:
   pkg.installed
 
@@ -57,6 +61,27 @@ salt-cloud-{{ dir }}:
     - template: jinja
     - makedirs: True
 {%- endfor %}
+
+{% for key, value in cloudmaps.items() %}
+/etc/salt/cloud.maps.d/{{ key }}:
+  file.managed:
+    - contents: |
+        {{ value|yaml(False) | indent(8) }}
+{% endfor %}
+
+{% for key, value in cloudprofiles.items() %}
+/etc/salt/cloud.profiles.d/{{ key }}:
+  file.managed:
+    - contents: |
+        {{ value|yaml(False) | indent(8) }}
+{% endfor %}
+
+{% for key, value in cloudproviders.items() %}
+/etc/salt/cloud.providers.d/{{ key }}:
+  file.managed:
+    - contents: |
+        {{ value|yaml(False) | indent(8) }}
+{% endfor %}
 
 salt-cloud-providers-permissions:
   file.directory:


### PR DESCRIPTION
It may be some time before we have templates for all of the possible cloud config files - especially given the number of cloud providers available. This pull requests gives the ability to configure the content of custom cloud map/profile/provider files directly from pillar data.