### PR TITLE
Add support for master eauth LDAP config

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -37,6 +37,11 @@ salt:
       ssl_key: /etc/pki/api/certs/server.key
       debug: False
       disable_ssl: False
+    ## for external auth - LDAP
+      # filter to use for Active Directory LDAP
+    auth.ldap.filter: {% raw %}'sAMAccountName={{username}}'{% endraw %}
+      # filter to use for Most other LDAP servers
+    auth.ldap.filter: {% raw %}'uid={{ username }}'{% endraw %}
 
   # salt minion config:
   minion:

--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -439,6 +439,68 @@ client_acl_blacklist:
 # Do not disable this unless it is absolutely clear what this does.
 {{ get_config('rotate_aes_key', 'True') }}
 
+# Unique ID attribute name for the user. For Active Directory should be set
+# to 'sAMAccountName'. Default value is 'memberUid'.
+{{ get_config('auth.ldap.accountattributename', 'memberUid') }}
+
+# Set this to True if LDAP is Active Directory. Default is False
+{{ get_config('auth.ldap.activedirectory', False) }}
+
+# Bind to LDAP anonymously to determine group membership
+# Active Directory does not allow anonymous binds without special configuration
+{{ get_config('auth.ldap.anonymous', False) }}
+
+# The base DN under which users can be found in LDAP
+{{ get_config('auth.ldap.basedn', '') }}
+
+# The user Salt authenticates to search for a users' Distinguished Name and 
+# group membership.
+{{ get_config('auth.ldap.binddn', '') }}
+
+# The bind password to go along with the bind dn (binddn). 
+{{ get_config('auth.ldap.bindpw', '') }}
+
+# The filter used to find the DN associated with a user. For most LDAPs use
+# the value {% raw %}'uid={{ username }}'{% endraw %}. For Active Directory use the value 
+# {% raw %}'sAMAccountName={{username}}'{% endraw %}. 
+{{ get_config('auth.ldap.filter', '') }}
+
+# The attribute used for user group membership. Defaults to 'memberOf'
+{{ get_config('auth.ldap.groupattribute', 'memberOf') }}
+
+# LDAP group class. Use 'group' for Active Directory. Defaults to 'posixGroup'
+{{ get_config('auth.ldap.groupclass', 'posixGroup') }}
+
+# To specify an OU that contains group data. Not used for Active Directory
+# Default value: 'Groups'
+{{ get_config('auth.ldap.groupou', 'Groups') }}
+
+# Allows the administrator to strip off a certain set of domain names 
+# so the hostnames looked up in the directory service can match the minion IDs.
+{{ get_config('auth.ldap.minion_stripdomains', []) }}
+
+# Verify server's TLS certificate. Default value: False
+{{ get_config('auth.ldap.no_verify', False) }}
+
+# Only for Active Directory. Default value: 'person'
+{{ get_config('auth.ldap.persontype', 'person') }}
+
+# Port to connect via. Default value: '389'
+{{ get_config('auth.ldap.port', '389') }}
+
+# LDAP scope level, almost always 2. Default value: 2
+{{ get_config('auth.ldap.scope', 2) }}
+
+# Server to auth against. Default value: 'localhost'
+{{ get_config('auth.ldap.server', 'localhost') }}
+
+# Use TLS when connecting. Default value: False
+{{ get_config('auth.ldap.tls', False) }}
+
+# Server specified in URI format. Overrides .ldap.server, .ldap.port,
+# .ldap.tls. Default value: ''
+{{ get_config('auth.ldap.uri', '') }}
+
 #####     Salt-SSH Configuration     #####
 ##########################################
 


### PR DESCRIPTION
This PR adds support for the `auth.ldap.*` parameters in the master `f_defaults.conf` file.