### PR TITLE
Render config as JSON

### DIFF
--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -6,11 +6,11 @@
 {% set cfg_minion = cfg_salt.get('minion', {}) -%}
 {%- macro get_config(configname, default_value) -%}
 {%- if configname in cfg_minion -%}
-{{ configname }}: {{ cfg_minion[configname] }}
+{{ configname }}: {{ cfg_minion[configname]|json }}
 {%- elif configname in cfg_salt and configname not in reserved_keys -%}
-{{ configname }}: {{ cfg_salt[configname] }}
+{{ configname }}: {{ cfg_salt[configname]|json }}
 {%- else -%}
-#{{ configname }}: {{ default_value }}
+#{{ configname }}: {{ default_value|json }}
 {%- endif -%}
 {%- endmacro -%}
 {%- from 'salt/formulas.jinja' import file_roots, formulas with context -%}


### PR DESCRIPTION
This avoid to have `null` value rendered as `None` string. I hit this bug in `grains`.