### PR TITLE
JSON encode values embedded in the salt-master's configuration file

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -5,11 +5,11 @@
 {% set cfg_master = cfg_salt.get('master', {}) -%}
 {%- macro get_config(configname, default_value) -%}
 {%- if configname in cfg_master -%}
-{{ configname }}: {{ cfg_master[configname] }}
+{{ configname }}: {{ cfg_master[configname]|json }}
 {%- elif configname in cfg_salt and configname not in reserved_keys -%}
-{{ configname }}: {{ cfg_salt[configname] }}
+{{ configname }}: {{ cfg_salt[configname]|json }}
 {%- else -%}
-#{{ configname }}: {{ default_value }}
+#{{ configname }}: {{ default_value|json }}
 {%- endif -%}
 {%- endmacro -%}
 {%- from 'salt/formulas.jinja' import file_roots, formulas with context -%}


### PR DESCRIPTION
This avoids problems when values are strings containing colons. And it
mimicks what was already done for the salt-minion's configuration file.

Fixes #233.