### PR TITLE
add module_config for minions

### DIFF
--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -927,6 +927,14 @@ ext_pillar:
 # A dict for the test module:
 #test.baz: {spam: sausage, cheese: bread}
 #
+
+
+{%- if 'module_config' in cfg_minion %}
+    {%- for modkey, modval in cfg_minion.module_config.items() %}
+{{ modkey }}: {{ modval }}
+    {%- endfor %}
+{%- endif %}
+
 #
 ######      Update settings          ######
 ###########################################


### PR DESCRIPTION
should allow to set module configuration for minions

in pillar:
salt:minion:
module_config:
      test: True
      test.foo: foo
      test.bar:
        - baz
        - quo
      test.baz: