### PR TITLE
Improve limitations related to `git.latest` in `salt.formulas`

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -319,6 +319,9 @@ salt_formulas:
     user: root
     group: root
     mode: 755
+  # Explicitly checkout the original branch for repos after the
+  # git.latest states have been processed (False by default)
+  checkout_orig_branch: False
   # List of formulas to enable in each environment
   list:
     base:

--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -53,3 +53,6 @@ salt:
       providers: salt://salt/files/cloud.providers.d
       profiles: salt://salt/files/cloud.profiles.d
       maps: salt://salt/files/cloud.maps.d
+
+salt_formulas:
+  checkout_orig_branch: False

--- a/salt/formulas.jinja
+++ b/salt/formulas.jinja
@@ -2,7 +2,9 @@
     'baseurl': 'https://github.com/saltstack-formulas',
     'basedir': '/srv/formulas',
     'update': False,
-    'options': {},
+    'options': {
+      'branch': 'master',
+    },
    }
 %}
 {% set formulas = salt['pillar.get']('salt_formulas:list', {}) %}

--- a/salt/formulas.jinja
+++ b/salt/formulas.jinja
@@ -14,6 +14,13 @@
 {{ value|yaml }}
 {%- endmacro -%}
 
+{%- macro formulas_opts_for_git_latest(env) -%}
+{%- set options = defaults['options'] or {} -%}
+{%- do options.update(salt['pillar.get']('salt_formulas:git_opts:default:options') or {}) -%}
+{%- do options.update(salt['pillar.get']('salt_formulas:git_opts:{0}:options'.format(env)) or {}) -%}
+{{ options|yaml }}
+{%- endmacro -%}
+
 {%- macro formulas_roots(env) -%}
 {%- set value = [] -%}
 {%- for dir in formulas.get(env, []) -%}

--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -2,6 +2,7 @@
 {% set processed_basedirs = [] %}
 
 {% from "salt/formulas.jinja" import formulas_git_opt with context %}
+{% from "salt/formulas.jinja" import formulas_opts_for_git_latest with context %}
 
 # Loop over all formulas listed in pillar data
 {% for env, entries in salt['pillar.get']('salt_formulas:list', {}).items() %}
@@ -25,7 +26,7 @@
 # Setup the formula Git repository
 {% if gitdir not in processed_gitdirs %}
 {% do processed_gitdirs.append(gitdir) %}
-{% set options = formulas_git_opt(env, 'options')|load_yaml %}
+{% set options = formulas_opts_for_git_latest(env)|load_yaml %}
 {% set baseurl = formulas_git_opt(env, 'baseurl')|load_yaml %}
 {{ gitdir }}:
   git.latest:

--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -1,4 +1,4 @@
-{% set processed_gitdirs = [] %}
+{% set processed_gitdir_envs = [] %}
 {% set processed_basedirs = [] %}
 
 {% from "salt/formulas.jinja" import formulas_git_opt with context %}
@@ -24,11 +24,12 @@
 {% endif %}
 
 # Setup the formula Git repository
-{% if gitdir not in processed_gitdirs %}
-{% do processed_gitdirs.append(gitdir) %}
+{% set gitdir_env = '{0}_{1}'.format(gitdir, env) %}
+{% if gitdir_env not in processed_gitdir_envs %}
+{% do processed_gitdir_envs.append(gitdir_env) %}
 {% set options = formulas_opts_for_git_latest(env)|load_yaml %}
 {% set baseurl = formulas_git_opt(env, 'baseurl')|load_yaml %}
-{{ gitdir }}:
+{{ gitdir_env }}:
   git.latest:
     - name: {{ baseurl }}/{{ entry }}.git
     - target: {{ gitdir }}

--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -1,6 +1,8 @@
+{% set processed_gitdirs = {} %}
 {% set processed_gitdir_envs = [] %}
 {% set processed_basedirs = [] %}
 
+{% from "salt/map.jinja" import formulas_settings with context %}
 {% from "salt/formulas.jinja" import formulas_git_opt with context %}
 {% from "salt/formulas.jinja" import formulas_opts_for_git_latest with context %}
 
@@ -11,6 +13,15 @@
 {% set basedir = formulas_git_opt(env, 'basedir')|load_yaml %}
 {% set gitdir = '{0}/{1}'.format(basedir, entry) %}
 {% set update = formulas_git_opt(env, 'update')|load_yaml %}
+
+{% if formulas_settings.checkout_orig_branch %}
+{% if not salt['file.directory_exists']('{0}/{1}'.format(gitdir, '.git')) %}
+{% set gitdir_branch = '' %}
+{% else %}
+{% set gitdir_branch = salt['git.current_branch'](gitdir) %}
+{% endif %}
+{% do processed_gitdirs.update({gitdir:gitdir_branch}) %}
+{% endif %}
 
 # Setup the directory hosting the Git repository
 {% if basedir not in processed_basedirs %}
@@ -29,6 +40,7 @@
 {% do processed_gitdir_envs.append(gitdir_env) %}
 {% set options = formulas_opts_for_git_latest(env)|load_yaml %}
 {% set baseurl = formulas_git_opt(env, 'baseurl')|load_yaml %}
+
 {{ gitdir_env }}:
   git.latest:
     - name: {{ baseurl }}/{{ entry }}.git
@@ -42,6 +54,23 @@
     - unless: test -e {{ gitdir }}
     {%- endif %}
 {% endif %}
+{% endfor %}
+{% endfor %}
 
+{% if formulas_settings.checkout_orig_branch %}
+# For each directory processed, explicitly checkout the original branch before
+# the `git.latest` state ran
+{% for gitdir, original_branch in processed_gitdirs.items() %}
+{% if original_branch %}
+{% set gitdir_user = salt['file.get_user'](gitdir) %}
+checkout_original_branch_for_{{ gitdir }}:
+  module.run:
+    - name: git.checkout
+    - order: last
+    - cwd: {{ gitdir }}
+    - rev: {{ original_branch }}
+    - user: {{ gitdir_user }}
+    - unless: test "$(cd {{ gitdir }}; git rev-parse --abbrev-ref HEAD)" = "{{ original_branch }}"
+{% endif %}
 {% endfor %}
-{% endfor %}
+{% endif %}

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -189,7 +189,7 @@ that differ from whats in defaults.yaml
 {## Merge the flavor_map to the default settings ##}
 {% do deep_merge(default_settings.salt,os_family_map) %}
 
-{## Merge in salt:lookup pillar ##}
+{## Merge in salt pillar ##}
 {% set salt_settings = salt['pillar.get'](
     'salt',
     default=default_settings.salt,

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -195,3 +195,10 @@ that differ from whats in defaults.yaml
     default=default_settings.salt,
     merge=True)
 %}
+
+{## Merge in salt_formulas pillar ##}
+{% set formulas_settings = salt['pillar.get'](
+    'salt_formulas',
+    default=default_settings.salt_formulas,
+    merge=True)
+%}


### PR DESCRIPTION
#### c00faca

Quoting from `pillar.example`:

``` yaml
salt_formulas:
  git_opts:
    # The Git options can be customized differently for each
    # environment, if an option is missing in a given environment, the
    # value from "default" is used instead.
    default:
      ...
```

This appears to work well in general except for the `Options passed directly to the git.latest state`.  Consider the example below:

``` yaml
    default:
      ...
      # Options passed directly to the git.latest state
      options:
        branch: master
        remote: origin
        rev: master
        user: myii
    dev:
      ...
      options:
        branch: dev
        rev: dev
```

Compare the results before and after this commit for the `dev` env:

``` yaml
Old: {'rev': 'dev', 'branch': 'dev'}
New: {'remote': 'origin', 'rev': 'dev', 'user': 'myii', 'branch': 'dev'}
```

Now the `default` options propagate as expected.
#### b957bb7

The previous commit now allows this more appropriate resolution for #238.
#### 2f56cc9

I was going to put this in a separate PR but since it's closely related, I've put it here anyway -- can always put in an another PR if required.

``` jinja
{% do processed_gitdirs.append(gitdir) %}
```

This line only allows one `env` to use the same `gitdir`.  This commit has relaxed the constraint slightly by limiting to the combination of both instead, i.e. `gitdir_env`.

With this in place, can automatically track and merge upstream changes using an `env` pulling to a separate branch, a simplified example being:

``` yaml
salt_formulas:
  git_opts:
    default:
      ...
      options:
        branch: master
        remote: origin
        rev: master
        user: myii
    base:
      ...
    upstream:
      ...
      options:
        branch: upstream
        remote: upstream
  list:
    base:
      - nginx-formula
    upstream:
      - nginx-formula
```
