### PR TITLE
https for the ubuntu repo and option to remove /etc/salt/minion.

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -7,6 +7,9 @@ salt:
   # This state will remove "/etc/salt/minion" when you set this to true.
   minion_remove_config: True
 
+  # This state will remove "/etc/salt/master" when you set this to true.
+  master_remove_config: True
+
   # Set this to False to not have the formula install packages (in the case you
   # install Salt via git/pip/etc.)
   install_packages: True

--- a/pillar.example
+++ b/pillar.example
@@ -4,6 +4,9 @@ salt:
   # and up as it'll wipe out important files that Salt relies on.
   clean_config_d_dir: False
 
+  # This state will remove "/etc/salt/minion" when you set this to true.
+  minion_remove_config: True
+
   # Set this to False to not have the formula install packages (in the case you
   # install Salt via git/pip/etc.)
   install_packages: True
@@ -129,7 +132,7 @@ salt:
   # salt cloud config
   cloud:
     master: salt
-    
+
     # For non-templated custom cloud provider/profile/map files
     providers:
       provider-filename1.conf:
@@ -158,7 +161,7 @@ salt:
       map-filename1.map:
         server-non-prod:
           - host.mycompany.com:
-              grains: 
+              grains:
                 environment: dev1
 
     # You can take profile and map templates from an alternate location

--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -7,6 +7,7 @@ salt:
   config_path: /etc/salt
 
   minion_remove_config: False
+  master_remove_config: False
 
   minion_service: salt-minion
   master_service: salt-master

--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -6,6 +6,8 @@ salt:
 
   config_path: /etc/salt
 
+  minion_remove_config: False
+
   minion_service: salt-minion
   master_service: salt-master
   api_service: salt-api

--- a/salt/master.sls
+++ b/salt/master.sls
@@ -21,6 +21,12 @@ salt-master:
       - file: salt-master
       - file: remove-old-master-conf-file
 
+{% if salt_settings.master_remove_config %}
+remove-default-master-conf-file:
+  file.absent:
+    - name: {{ salt_settings.config_path }}/master
+{% endif %}
+
 # clean up old _defaults.conf file if they have it around
 remove-old-master-conf-file:
   file.absent:

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -23,6 +23,12 @@ salt-minion:
       - file: salt-minion
       - file: remove-old-minion-conf-file
 
+{% if salt_settings.minion_remove_config %}
+remove-default-minion-conf-file:
+  file.absent:
+    - name: {{ salt_settings.config_path }}/minion
+{% endif %}
+
 # clean up old _defaults.conf file if they have it around
 remove-old-minion-conf-file:
   file.absent:

--- a/salt/pkgrepo/ubuntu/init.sls
+++ b/salt/pkgrepo/ubuntu/init.sls
@@ -1,5 +1,5 @@
 saltstack-pkgrepo:
   pkgrepo.managed:
-    - name: deb http://repo.saltstack.com/apt/ubuntu/{{ grains['lsb_distrib_release'] }}/amd64/latest {{ grains['lsb_distrib_codename'] }} main
+    - name: deb https://repo.saltstack.com/apt/ubuntu/{{ grains['lsb_distrib_release'] }}/amd64/latest {{ grains['lsb_distrib_codename'] }} main
     - file: /etc/apt/sources.list.d/saltstack.list
     - key_url: https://repo.saltstack.com/apt/ubuntu/{{ grains['lsb_distrib_release'] }}/amd64/latest/SALTSTACK-GPG-KEY.pub


### PR DESCRIPTION
This PR adds both,

the https uri is something not all people want:
- if they dont have apt-transport-https
- salt doesnt detect theres a http repo which means this repo will get added a second time