### PR TITLE
Fix URLs in salt.pkgrepo for Raspbian & Ubuntu

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -94,7 +94,18 @@ that differ from whats in defaults.yaml
       'config_path': 'C:\salt\conf',
       'minion_service': 'salt-minion',
     },
-  }, grain="os_family", merge=salt['pillar.get']('salt:lookup'))
+  }, merge=salt['grains.filter_by']({
+    'Ubuntu':  {
+      'pkgrepo': 'deb http://repo.saltstack.com/apt/' +
+      salt['grains.get']('os')|lower + '/' + osrelease + '/amd64/latest ' + salt['grains.get']('oscodename') + ' main',
+      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os')|lower + '/' + osrelease + '/amd64/latest/SALTSTACK-GPG-KEY.pub',
+    },
+    'Raspbian': {
+      'pkgrepo': 'deb http://repo.saltstack.com/apt/' +
+      salt['grains.get']('os_family')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/armhf/latest ' + salt['grains.get']('oscodename') + ' main',
+      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os_family')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/armhf/latest/SALTSTACK-GPG-KEY.pub',
+    },
+  }, grain='os', merge=salt['pillar.get']('salt:lookup')))
 %}
 
 {## Merge the flavor_map to the default settings ##}

--- a/salt/pkgrepo/init.sls
+++ b/salt/pkgrepo/init.sls
@@ -1,6 +1,6 @@
 {% set name = {
     'RedHat': 'redhat',
-    'Debian': grains['os']|lower,
+    'Debian': grains['os_family']|lower,
 }.get(grains.os_family) %}
 include:
   - .{{ name }}


### PR DESCRIPTION
Rasbian reports back the following grain values:
    
```
    local:
        ----------
        os:
            Raspbian
        os_family:
            Debian
        osarch:
            armhf
        osmajorrelease:
            8
        osrelease:
            8.0
```    
Ubuntu reports back the following grain values:
    
```
    local:
        ----------
        os:
            Ubuntu
        os_family:
            Debian
        osarch:
            amd64
        osmajorrelease:
            14
        osrelease:
            14.04

```
- For Raspbian the osarch needed to be changed from other Debain os_family distributions.
- For Ubuntu the osrelease value is needed instead of osmajorrelease as other Debian os_family distributions.

Part of #180