### PR TITLE
Handle config opts not part of default config.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ you control, then you can safely enable the
 
 ``Configuration``
 =================
-Every option available in the templates can be set in pillar. Settings under 'salt' will be overridden by more specific settings under ``salt['master']``, ``salt['minion']`` or ``salt['cloud']``
+Every option available in the templates can be set in pillar. Settings under 'salt' will be overridden by more specific settings under ``salt['master']``, ``salt['minion']`` or ``salt['cloud']``. Options specified in ``salt['minion']`` which are not present in the default configuration file will be added to the end of the configuration file.
 
 ::
 

--- a/pillar.example
+++ b/pillar.example
@@ -132,6 +132,10 @@ salt:
     mine_functions:
       network.interface_ip: [eth0]
 
+    # other 'non-default' config
+    auth_keytab: /root/auth.keytab
+    auth_principal: kadmin/admin
+
   # salt cloud config
   cloud:
     master: salt

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -4,7 +4,9 @@
 {% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs'] -%}
 {% set cfg_salt = pillar.get('salt', {}) -%}
 {% set cfg_minion = cfg_salt.get('minion', {}) -%}
+{% set default_keys = [] -%}
 {%- macro get_config(configname, default_value) -%}
+{%- do default_keys.append(configname) %}
 {%- if configname in cfg_minion -%}
 {{ configname }}: {{ cfg_minion[configname]|json }}
 {%- elif configname in cfg_salt and configname not in reserved_keys -%}
@@ -103,6 +105,7 @@ master:
 # same machine but with different ids, this can be useful for salt compute
 # clusters.
 {% if 'id' in cfg_minion -%}
+{%- do default_keys.append('id') %}
 id: {{ cfg_minion['id'] }}
 {% else -%}
 #id:
@@ -205,6 +208,7 @@ id: {{ cfg_minion['id'] }}
 {{ get_config('ping_interval', '0') }}
 
 {%- if 'mine_functions' in cfg_minion %}
+{%- do default_keys.append('mine_functions') %}
 mine_functions:
 {%- for func, args in cfg_minion['mine_functions'].items() %}
   {{ func }}: {{ args }}
@@ -336,6 +340,7 @@ mine_functions:
 #
 # Include a config file from some other path:
 {% if 'include' in cfg_minion -%}
+{%- do default_keys.append('include') %}
     {% if isinstance(cfg_minion['include'], list) -%}
         include:
         {% for include in cfg_minion['include'] -%}
@@ -483,6 +488,7 @@ file_client: local
 #     - /srv/salt/prod/services
 #     - /srv/salt/prod/states
 {% if 'file_roots' in cfg_minion -%}
+{%- do default_keys.append('file_roots') %}
 {{ file_roots(cfg_minion['file_roots']) }}
 {%- elif 'file_roots' in cfg_salt -%}
 {{ file_roots(cfg_salt['file_roots']) }}
@@ -511,6 +517,7 @@ file_client: local
 #  - git
 #  - roots
 {% if 'fileserver_backend' in cfg_minion -%}
+{%- do default_keys.append('fileserver_backend') %}
 fileserver_backend:
 {%- for backend in cfg_minion['fileserver_backend'] %}
   - {{ backend }}
@@ -570,6 +577,7 @@ fileserver_backend:
 # Note:  file:// repos will be treated as a remote, so refs you want used must
 # exist in that repo as *local* refs.
 {% if 'gitfs_remotes' in cfg_minion -%}
+{%- do default_keys.append('gitfs_remotes') %}
 gitfs_remotes:
 {%- for remote in cfg_minion['gitfs_remotes'] %}
 {%- if remote is iterable and remote is not string %}
@@ -602,6 +610,7 @@ gitfs_remotes:
 # The gitfs_env_whitelist and gitfs_env_blacklist parameters allow for greater
 # control over which branches/tags are exposed as fileserver environments.
 {% if 'gitfs_env_whitelist' in cfg_minion -%}
+{%- do default_keys.append('gitfs_env_whitelist') %}
 gitfs_env_whitelist:
   {%- for git_env in cfg_minion['gitfs_env_whitelist'] %}
   - {{ git_env }}
@@ -613,6 +622,7 @@ gitfs_env_whitelist:
 {% endif %}
 
 {% if 'gitfs_env_blacklist' in cfg_minion -%}
+{%- do default_keys.append('gitfs_env_blacklist') %}
 gitfs_env_blacklist:
   {%- for git_env in cfg_minion['gitfs_env_blacklist'] %}
   - {{ git_env }}
@@ -629,6 +639,7 @@ gitfs_env_blacklist:
 # this is the case, and pillar data is defined, then the pillar_roots need to
 # also be configured on the minion:
 {% if 'pillar_roots' in cfg_minion -%}
+{%- do default_keys.append('pillar_roots') %}
 pillar_roots:
 {%- for name, roots in cfg_minion['pillar_roots']|dictsort %}
   {{ name }}:
@@ -651,6 +662,7 @@ pillar_roots:
 {%- endif %}
 
 {% if 'ext_pillar' in cfg_minion %}
+{%- do default_keys.append('ext_pillar') %}
 ext_pillar:
 {%- for pillar in cfg_minion['ext_pillar'] -%}
   {%- for key in pillar -%}
@@ -930,6 +942,7 @@ ext_pillar:
 
 
 {%- if 'module_config' in cfg_minion %}
+{%- do default_keys.append('module_config') %}
     {%- for modkey, modval in cfg_minion.module_config.items() %}
 {{ modkey }}: {{ modval }}
     {%- endfor %}
@@ -993,6 +1006,7 @@ ext_pillar:
 {{ get_config('event_match_type', 'startswith') }}
 
 {% if 'mongo' in cfg_minion -%}
+{%- do default_keys.append('mongo') %}
 #####   mongodb connection settings  #####
 ##########################################
 {%- for name, value in cfg_minion['mongo'].items() %}
@@ -1000,8 +1014,17 @@ mongo.{{ name }}: {{ value }}
 {%- endfor %}
 
 {% if 'alternative.mongo' in cfg_minion -%}
+{%- do default_keys.append('alternative.mongo') %}
 {%- for name, value in cfg_minion['alternative.mongo'].items() %}
 alternative.mongo.{{ name }}: {{ value }}
 {%- endfor %}
 {% endif %}
 {%- endif %}
+
+############  Other settings  ############
+##########################################
+{%- for configname in cfg_minion %}
+{%- if configname not in reserved_keys and configname not in default_keys %}
+{{ configname }}: {{ cfg_minion[configname]|json }}
+{%- endif %}
+{%- endfor %}

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -1021,8 +1021,6 @@ alternative.mongo.{{ name }}: {{ value }}
 {% endif %}
 {%- endif %}
 
-############  Other settings  ############
-##########################################
 {%- for configname in cfg_minion %}
 {%- if configname not in reserved_keys and configname not in default_keys %}
 {{ configname }}: {{ cfg_minion[configname]|json }}


### PR DESCRIPTION
This is PR to solve #246 - allowing config options to be added to the minion pillar (for minion.d) that aren't part of the default config file.
