### PR TITLE
By default don't install cloud dependencies using pip

### DIFF
--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -4,6 +4,7 @@
 {% set cloudprofiles = salt['pillar.get']('salt:cloud:profiles', {}) -%}
 {% set cloudproviders = salt['pillar.get']('salt:cloud:providers', {}) -%}
 
+{%- if salt_settings.use_pip %}
 python-pip:
   pkg.installed
 
@@ -23,17 +24,20 @@ apache-libcloud:
   pip.installed:
     - require:
       - pkg: python-pip
+{%- endif %}
 
 {% if salt_settings.install_packages %}
 salt-cloud:
   pkg.installed:
     - name: {{ salt_settings.salt_cloud }}
+    {%- if salt_settings.use_pip %}
     - require:
       - pip: apache-libcloud
       - pip: pycrypto
       {% if grains['os_family'] not in ['Debian', 'RedHat'] %}
       - pip: crypto
       {% endif %}
+    {%- endif %}
 {% endif %}
 
 {% for cert in pillar.get('salt_cloud_certs', {}) %}

--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -2,6 +2,7 @@
 # vim: ft=yaml
 salt:
   install_packages: True
+  use_pip: False
   clean_config_d_dir: True
 
   config_path: /etc/salt


### PR DESCRIPTION
The salt-cloud packages automatically pull in the pycrypto and libcloud dependencies for RedHat and Debian (at least when using the SaltStack repos), so it doesn't really make sense to install these dependencies using pip. By default we no longer use pip, but the old behaviour can be restored by setting 'salt:use_pip' to True in the pillar.

There could probably be a case made for removing the pip stuff altogether, but we will leave it in for the time being to preserve some backwards compatibility.