### PR TITLE
add engine and reactor config to salt minion configuration

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -141,6 +141,23 @@ salt:
     auth_keytab: /root/auth.keytab
     auth_principal: kadmin/admin
 
+		# optional engine configuration
+    engines:
+      slack:
+        token: xoxp-XXXXX-XXXXXXX
+        control: True
+        valid_users:
+          - someuser
+          - otheruser
+        valid_commands:
+          - test.ping
+          - list_jobs
+        aliases:
+          list_jobs:
+            type: runner
+            cmd: jobs.list_jobs
+
+
   # salt cloud config
   cloud:
     master: salt


### PR DESCRIPTION
In preparation of the new release I would like to have the option to configure the reactor and engine config on a salt minion as well:

see: 
https://docs.saltstack.com/en/develop/ref/engines/all/salt.engines.reactor.html

config engines:
https://github.com/saltstack/salt/pull/29245

sync engines:
https://github.com/saltstack/salt/pull/32507


