### PR TITLE
add option to start minion service if master_type is set to disable

### DIFF
--- a/salt/standalone.sls
+++ b/salt/standalone.sls
@@ -13,7 +13,11 @@ salt-minion:
     - exclude_pat: _*
     - context:
         standalone: True
+{%- if salt_settings.minion.master_type is defined and salt_settings.minion.master_type == 'disable' %}
+  service.running:
+{%- else %}
   service.dead:
+{%- endif %}
     - enable: False
     - name: {{ salt_settings.minion_service }}
     - require:


### PR DESCRIPTION
This feature will enable salt-minion service if master_type is set to disable on standalone minions.

From the config file:
```
Setting master_type to 'disable' let's you have a running minion (with engines and
# beacons) without a master connection
```