### PR TITLE
fix minion daemon to be enabled if master_type is set to disable

### DIFF
--- a/salt/standalone.sls
+++ b/salt/standalone.sls
@@ -15,10 +15,11 @@ salt-minion:
         standalone: True
 {%- if salt_settings.minion.master_type is defined and salt_settings.minion.master_type == 'disable' %}
   service.running:
+    - enable: True
 {%- else %}
   service.dead:
-{%- endif %}
     - enable: False
+{%- endif %}
     - name: {{ salt_settings.minion_service }}
     - require:
 {% if salt_settings.install_packages %}


### PR DESCRIPTION
forgot to set the minion service to enable if master_type is set to disable.
