### PR TITLE
make the configuration of engines specific to master or minion

### DIFF
--- a/salt/files/master.d/engine.conf
+++ b/salt/files/master.d/engine.conf
@@ -1,7 +1,8 @@
 #
 # This file is managed by Salt! Do not edit by hand!
 #
-{%- set engines = salt['pillar.get']('salt:master:engines') -%}
+{%- set engines = salt['pillar.get']('salt:engines') -%}
+{%- set engines = salt['pillar.get']('salt:master:engines', default=engines, merge=True) -%}
 {%- if engines %}
 engines:
   {{ engines | yaml(False) | indent(2) }}

--- a/salt/files/master.d/engine.conf
+++ b/salt/files/master.d/engine.conf
@@ -1,7 +1,7 @@
 #
 # This file is managed by Salt! Do not edit by hand!
 #
-{%- set engines = salt['pillar.get']('salt:engines') -%}
+{%- set engines = salt['pillar.get']('salt:master:engines') -%}
 {%- if engines %}
 engines:
   {{ engines | yaml(False) | indent(2) }}

--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -1,6 +1,6 @@
 # This file managed by Salt, do not edit by hand!!
 # Based on salt version 2015.8.7 default config
-{% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs'] -%}
+{% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs', 'engines'] -%}
 {% set cfg_salt = pillar.get('salt', {}) -%}
 {% set cfg_master = cfg_salt.get('master', {}) -%}
 {%- macro get_config(configname, default_value) -%}

--- a/salt/files/minion.d/engine.conf
+++ b/salt/files/minion.d/engine.conf
@@ -1,7 +1,7 @@
 #
 # This file is managed by Salt! Do not edit by hand!
 #
-{%- set engines = salt['pillar.get']('salt:engines') -%}
+{%- set engines = salt['pillar.get']('salt:minion:engines') -%}
 {%- if engines %}
 engines:
   {{ engines | yaml(False) | indent(2) }}

--- a/salt/files/minion.d/engine.conf
+++ b/salt/files/minion.d/engine.conf
@@ -1,7 +1,8 @@
 #
 # This file is managed by Salt! Do not edit by hand!
 #
-{%- set engines = salt['pillar.get']('salt:minion:engines') -%}
+{%- set engines = salt['pillar.get']('salt:engines') -%}
+{%- set engines = salt['pillar.get']('salt:minion:engines', default=engines, merge=True) -%}
 {%- if engines %}
 engines:
   {{ engines | yaml(False) | indent(2) }}

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -1,7 +1,7 @@
 # This file managed by Salt, do not edit by hand!!
 #  Based on salt version 2015.8.7 default config
 #
-{% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs'] -%}
+{% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs', 'engines'] -%}
 {% set cfg_salt = pillar.get('salt', {}) -%}
 {% set cfg_minion = cfg_salt.get('minion', {}) -%}
 {% set default_keys = [] -%}


### PR DESCRIPTION
the engines are now configured using the following pillars:
- salt.master.engines
- salt.minion.engines

instead of a global salt.engines pillar.

Note: the pillar.example provided seems to assume this behaviour.
(the pillar is salt.master.engines.slack and not salt.engines.slack)

https://github.com/saltstack-formulas/salt-formula/blob/master/pillar.example#L83
