### PR TITLE
typo - top_file_merging_strategy (f_defaults.conf) template

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -650,7 +650,7 @@ master_tops:
 # default behaviour is an unordered merge. To prevent top files from
 # being merged together and instead to only use the top file from the
 # requested environment, set this value to 'same'.
-{{ get_config('top_file_merging_stragety', 'merge') }}
+{{ get_config('top_file_merging_strategy', 'merge') }}
 
 # To specify the order in which environments are merged, set the ordering
 # in the env_order option. Given a conflict, the last matching value will


### PR DESCRIPTION
Fix typo in salt/files/master.d/f_defaults.conf template.