### PR TITLE
Add state that ensures pkgrepo for RedHat is absent

### DIFF
--- a/salt/pkgrepo/redhat/absent.sls
+++ b/salt/pkgrepo/redhat/absent.sls
@@ -1,0 +1,3 @@
+drop-saltstack-pkgrepo:
+  pkgrepo.absent:
+    - name: saltstack-pkgrepo


### PR DESCRIPTION
I found it strange that this file exists yet does nothing.
