### PR TITLE
Change default value for pillar_opts

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -983,7 +983,7 @@ ext_pillar:
 # The pillar_opts option adds the master configuration file data to a dict in
 # the pillar called "master". This is used to set simple configurations in the
 # master config file that can then be used on minions.
-{{ get_config('pillar_opts', 'True') }}
+{{ get_config('pillar_opts', 'False') }}
 
 # The pillar_safe_render_error option prevents the master from passing pillar
 # render errors to the minion. This is set on by default because the error could


### PR DESCRIPTION
The value of ``pillar_opts`` changed its default since 2015.2 release, so we should update it here to avoid confusion. For reference please see https://github.com/saltstack/salt/commit/64060782402ee83b25612f9ad474f7fdf63c7d67