### PR TITLE
Add SmartOS salt-master, minion and gitfs support

### DIFF
--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -23,6 +23,7 @@ salt:
   salt_ssh: salt-ssh
 
   python_git: python-git
+  python_dulwich: python-dulwich
 
   master:
     gitfs_provider: gitpython

--- a/salt/gitfs/dulwich.sls
+++ b/salt/gitfs/dulwich.sls
@@ -15,7 +15,9 @@ install-dulwich:
     - name: dulwich
 
 {% else %}
-# install from package
-# TODO haven't actually found a distro that has a good version to test
+
+python-dulwich:
+  pkg.installed:
+    - name: {{ salt_settings.python_dulwich }}
 
 {% endif %}

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -142,6 +142,25 @@ that differ from whats in defaults.yaml
       salt['grains.get']('os_family')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/armhf/latest ' + salt['grains.get']('oscodename') + ' main',
       'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os_family')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/armhf/latest/SALTSTACK-GPG-KEY.pub',
     },
+    'SmartOS': {
+      'salt_master': 'salt',
+      'salt_minion': 'salt',
+      'salt_syndic': 'salt',
+      'salt_cloud': 'salt',
+      'salt_api': 'salt',
+      'salt_ssh': 'salt',
+      'minion_service': 'salt:minion',
+      'master_service': 'salt:master',
+      'python_dulwich': 'py27-dulwich',
+      'gitfs': {
+        'dulwich': {
+          'install_from_source': False,
+        }
+      },
+      'master': {
+        'gitfs_provider': 'dulwich'
+      },
+    }
   }, grain='os', merge=salt['pillar.get']('salt:lookup')))
 %}
 


### PR DESCRIPTION
Adds support for SmartOS zones for master, minion and gitfs. Tested against SmartOS 20161110T013148Z