### PR TITLE
Correct SmartOS config path

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -157,6 +157,7 @@ that differ from whats in defaults.yaml
           'install_from_source': False,
         }
       },
+      'config_path': '/opt/local/etc/salt',
       'master': {
         'gitfs_provider': 'dulwich'
       },


### PR DESCRIPTION
Previous PR didn't set the salt config path. This fixes that.

gitfs_provider isn't being set to dulwich as per the defaults, not sure if it should - will investigate further and to another PR for that.