### PR TITLE
Have salt-api service watch the master config files

### DIFF
--- a/salt/api.sls
+++ b/salt/api.sls
@@ -13,7 +13,8 @@ salt-api:
     - name: {{ salt_settings.api_service }}
     - require:
       - service: {{ salt_settings.master_service }}
-{% if salt_settings.install_packages %}
     - watch:
+{% if salt_settings.install_packages %}
       - pkg: salt-api
 {% endif %}
+      - file: salt-master


### PR DESCRIPTION
The salt-api service is configured using the master config files but is not restarted when the master is restarted. We need the salt-api service to watch the master config files to ensure that any config changes are picked up.