### PR TITLE
Fix pygit2-libgit2 builds on Debian like platforms.

### DIFF
--- a/salt/gitfs/pygit2.sls
+++ b/salt/gitfs/pygit2.sls
@@ -23,6 +23,7 @@ pygit-deps:
   pkg.installed:
     - pkgs:
       - build-essential
+      - pkg-config
       - python-dev
       - libssh-dev
       - libffi-dev


### PR DESCRIPTION
On Ubuntu Trusty/Xenial LXD images pkg-config is not installed and its no dependency on all of "build-essential" so it does not get installed.

This PR adds **pkg-config** as dependency so libgit2 works with ssh:// and https:// git urls.