### PR TITLE
 Use a different group name for GID 0 depending on the minion's O/S

### DIFF
--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -48,7 +48,12 @@ cloud-cert-{{ cert }}-pem:
     - source: salt://{{ slspath }}/files/key
     - template: jinja
     - user: root
-    - group: root
+    - group:
+        {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD'] %}
+        wheel
+        {%- else %}
+        root
+        {%- endif %}
     - mode: 600
     - makedirs: True
     - defaults:
@@ -91,7 +96,12 @@ salt-cloud-providers-permissions:
   file.directory:
     - name: {{ salt_settings.config_path }}/cloud.providers.d
     - user: root
-    - group: root
+    - group:
+        {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD'] %}
+        wheel
+        {%- else %}
+        root
+        {%- endif %}
     - file_mode: 600
     - dir_mode: 700
     - recurse:

--- a/salt/gitfs/keys.sls
+++ b/salt/gitfs/keys.sls
@@ -10,7 +10,12 @@ gitfs-key-{{ key }}-{{ type }}:
     - source: salt://salt/files/gitfs_key.jinja
     - template: jinja
     - user: root
-    - group: root
+    - group:
+        {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD'] %}
+        wheel
+        {%- else %}
+        root
+        {%- endif %}
     - mode: 600
     - makedirs: True
     - defaults:


### PR DESCRIPTION
Some Unix variants name GID 0 "wheel".  Unfortunately, one cannot specify this group by ID, because Python conflates integer 0 with boolean False, nor can one specify this group using the string '0', because of assumptions in the Salt or Python codebases regarding group names.