### PR TITLE
Arch Linux: install pygit2 or libgit2 via pacman instead of source

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -90,6 +90,8 @@ that differ from whats in defaults.yaml
       'salt_cloud':  'salt',
       'salt_api': 'salt',
       'salt_ssh':  'salt',
+      'pygit2': 'python2-pygit2',
+      'libgit2': 'libgit2',
     },
     'FreeBSD': {
       'salt_master': 'py27-salt',


### PR DESCRIPTION
Changes default behaviour of install `pygit2` and `libgit2` via `pacman` instead of from source on Arch Linux.

Fixes #284 