### PR TITLE
fix default value for minion beacons pillar

### DIFF
--- a/salt/files/minion.d/beacons.conf
+++ b/salt/files/minion.d/beacons.conf
@@ -1,7 +1,7 @@
 #
 # This file is managed by Salt! Do not edit by hand!
 #
-{%- set beacons = salt['pillar.get']('salt:beacons') -%}
+{%- set beacons = salt['pillar.get']('salt:beacons', {}) -%}
 {%- set beacons = salt['pillar.get']('salt:minion:beacons', default=beacons, merge=True) -%}
 {%- if beacons %}
 beacons:


### PR DESCRIPTION
Similar to pull request #279, for the minion beacons configuration file.

Dict merge will fail if previous value is not a dict.