### PR TITLE
fixed key reserved for lxc_profile file

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -1,6 +1,6 @@
 # This file managed by Salt, do not edit by hand!!
 # Based on salt version 2015.8.7 default config
-{% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs', 'engines'] -%}
+{% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs', 'engines', 'lxc.network_profile', 'lxc.container_profile'] -%}
 {% set cfg_salt = pillar.get('salt', {}) -%}
 {% set cfg_master = cfg_salt.get('master', {}) -%}
 {% set default_keys = [] -%}


### PR DESCRIPTION
The lxc keyword are not into the reserved keyword list of master configuration file, therefore the lxc configuration get copied also into the f_default file.