### PR TITLE
Hack to make rendering work on CentOS 6

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -960,22 +960,19 @@ pillar_roots:
 
 {% if 'ext_pillar' in cfg_master %}
 {%- do default_keys.append('ext_pillar') %}
-{#- workaround for missing mapping test in CentOS 6, part A #}
-{%- set is_mapping = {} %}
 ext_pillar:
 {%- for pillar in cfg_master['ext_pillar'] -%}
   {%- for key in pillar -%}
     {%- if pillar[key] is string %}
   - {{ key }}: {{ pillar[key] }}
-    {#- workaround for missing mapping test in CentOS 6, part B #}
-    {%- do is_mapping.update({key: type(pillar[key]) == type({})}) %}
-    {%- elif pillar[key] is iterable and not is_mapping[key] %}
+    {#- Workaround for missing `is mapping` on CentOS 6, see #193: #}
+    {%- elif pillar[key] is iterable and 'dict' not in pillar[key].__class__.__name__ %}
   - {{ key }}:
       {%- for parameter in pillar[key] %}
     - {{ parameter }}
       {%- endfor -%}
-    {#- workaround for missing mapping test in CentOS 6, part C #}
-    {%- elif is_mapping[key] and pillar[key] is not string %}
+    {#- Workaround for missing `is mapping` on CentOS 6, see #193: #}
+    {%- elif 'dict' in pillar[key].__class__.__name__ and pillar[key] is not string %}
   - {{ key }}: 
       {%- for parameter in pillar[key] %}
       {{ parameter }}: {{pillar[key][parameter]}}

--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -960,18 +960,23 @@ pillar_roots:
 
 {% if 'ext_pillar' in cfg_master %}
 {%- do default_keys.append('ext_pillar') %}
+{#- workaround for missing mapping test in CentOS 6, part A #}
+{%- set is_mapping = {} %}
 ext_pillar:
 {%- for pillar in cfg_master['ext_pillar'] -%}
   {%- for key in pillar -%}
     {%- if pillar[key] is string %}
   - {{ key }}: {{ pillar[key] }}
-    {%- elif pillar[key] is iterable and pillar[key] is not mapping %}
+    {#- workaround for missing mapping test in CentOS 6, part B #}
+    {%- do is_mapping.update({key: type(pillar[key]) == type({})}) %}
+    {%- elif pillar[key] is iterable and not is_mapping[key] %}
   - {{ key }}:
       {%- for parameter in pillar[key] %}
     - {{ parameter }}
       {%- endfor -%}
-    {%- elif pillar[key] is mapping and pillar[key] is not string %}
-  - {{ key }}:
+    {#- workaround for missing mapping test in CentOS 6, part C #}
+    {%- elif is_mapping[key] and pillar[key] is not string %}
+  - {{ key }}: 
       {%- for parameter in pillar[key] %}
       {{ parameter }}: {{pillar[key][parameter]}}
       {%- endfor %}

--- a/salt/files/master.d/lxc_profiles.conf
+++ b/salt/files/master.d/lxc_profiles.conf
@@ -12,7 +12,8 @@ lxc.container_profile:
 {%- for prof in cfg_prof %}
   {{ prof }}:
 {%- for conf in cfg_prof[prof] %}
-{%-   if cfg_prof[prof][conf] is mapping %}
+{#- Workaround for missing `is mapping` on CentOS 6, see #193 #}
+{%-   if 'dict' in cfg_prof[prof][conf].__class__.__name__ %}
     {{ conf }}:
 {%-      for opt in cfg_prof[prof][conf] %}
       {{ opt }}: {{ cfg_prof[prof][conf][opt] }}
@@ -29,7 +30,8 @@ lxc.network_profile:
 {%- for prof in cfg_net %}
   {{ prof }}:
 {%- for conf in cfg_net[prof] -%}
-{%-  if cfg_net[prof][conf] is mapping %}
+{#- Workaround for missing `is mapping` on CentOS 6, see #193 #}
+{%-  if 'dict' in cfg_net[prof][conf].__class__.__name__ %}
     {{ conf }}:
 {%-      for opt in cfg_net[prof][conf] %}
       {{ opt }}: {{ cfg_net[prof][conf][opt] }}

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -694,12 +694,14 @@ ext_pillar:
   {%- for key in pillar -%}
     {%- if pillar[key] is string %}
   - {{ key }}: {{ pillar[key] }}
-    {%- elif pillar[key] is iterable and pillar[key] is not mapping %}
+    {#- Workaround for missing `is mapping` on CentOS 6, see #193: #}
+    {%- elif pillar[key] is iterable and 'dict' not in pillar[key].__class__.__name__ %}
   - {{ key }}:
       {%- for parameter in pillar[key] %}
     - {{ parameter }}
       {%- endfor -%}
-    {%- elif pillar[key] is mapping and pillar[key] is not string %}
+    {#- Workaround for missing `is mapping` on CentOS 6, see #193: #}
+    {%- elif 'dict' in pillar[key].__class__.__name__ and pillar[key] is not string %}
   - {{ key }}:
       {%- for parameter in pillar[key] %}
       {{ parameter }}: {{pillar[key][parameter]}}

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -2,21 +2,25 @@
 # vim: ft=jinja
 
 {%- macro deep_merge(a, b) %}
+{#-     This whole `'dict' in x.__class__.__name__` mess is a 
+        workaround for the missing mapping test in CentOS 6's 
+        ancient Jinja2, see #193  #}
 {%-     for k,v in b.iteritems() %}
 {%-         if v is string or v is number %}
 {%-             do a.update({ k: v }) %}
-{%-         elif v is not mapping %}
+{%-         elif 'dict' not in v.__class__.__name__ %}
 {%-             if a[k] is not defined %}
 {%-                 do a.update({ k: v }) %}
-{%-             elif a[k] is iterable and a[k] is not mapping and a[k] is not string %}
+{%-             elif a[k] is iterable and 'dict' not in a[k].__class__.__name__ and 
+                a[k] is not string %}
 {%-                 do a.update({ k: v|list + a[k]|list}) %}
 {%-             else %}
 {%-                 do a.update({ k: v }) %}
 {%-             endif %}
-{%-         elif v is mapping %}
+{%-         elif 'dict' in v.__class__.__name__ %}
 {%-             if a[k] is not defined %}
 {%-                 do a.update({ k: v }) %}
-{%-             elif a[k] is not mapping %}
+{%-             elif 'dict' in a[k].__class__.__name__ %}
 {%-                 do a.update({ k: v }) %}
 {%-             else %}
 {%-                 do deep_merge(a[k], v) %}


### PR DESCRIPTION
 !!   Not tested with an actual   !!
 !!  configured `ext_pillar` yet  !!

- jinja on RHEL/CentOS 6 has no 'mapping'
  test (see salt-formula issue #193)
- {% do ... %} allows no assignment, only
  function calls
- of course, `type(foo) is dict` doesn't
  work because it's no jinja test
- maybe `.isinstance()` would be nicer/more
  reliable