### PR TITLE
Add new publisher_acl to salt master config

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -332,7 +332,24 @@ event_return_blacklist:
 # This setting should be treated with care since it opens up execution
 # capabilities to non root users. By default this capability is completely
 # disabled.
-{% if 'client_acl' in cfg_master -%}
+{% if 'publisher_acl' in cfg_master -%}
+{%- do default_keys.append('publisher_acl') %}
+publisher_acl:
+{%- for name, user in cfg_master['publisher_acl']|dictsort %}
+  {{ name}}:
+{%- for command in user %}
+    - {% raw %}'{% endraw %}{{ command }}{% raw %}'{% endraw %}
+{%- endfor -%}
+{%- endfor -%}
+{% elif 'publisher_acl' in cfg_salt -%}
+publisher_acl:
+{%- for name, user in cfg_salt['publisher_acl']|dictsort %}
+  {{ name }}:
+{%- for command in user %}
+    - {% raw %}'{% endraw %}{{ command }}{% raw %}'{% endraw %}
+{%- endfor -%}
+{%- endfor -%}
+{% elif 'client_acl' in cfg_master -%}
 {%- do default_keys.append('client_acl') %}
 client_acl:
 {%- for name, user in cfg_master['client_acl']|dictsort %}
@@ -350,7 +367,7 @@ client_acl:
 {%- endfor -%}
 {%- endfor -%}
 {% else -%}
-#client_acl:
+#publisher_acl:
 #  larry:
 #    - test.ping
 #    - network.*
@@ -361,7 +378,28 @@ client_acl:
 # This example would blacklist all non sudo users, including root from
 # running any commands. It would also blacklist any use of the "cmd"
 # module. This is completely disabled by default.
-{% if 'client_acl_blacklist' in cfg_master %}
+{% if 'publisher_acl_blacklist' in cfg_master %}
+{%- do default_keys.append('publisher_acl_blacklist') %}
+publisher_acl_blacklist:
+  users:
+  {% for user in cfg_master['publisher_acl_blacklist'].get('users', []) %}
+    - {{ user }}
+  {% endfor %}
+  modules:
+  {% for mod in cfg_master['publisher_acl_blacklist'].get('modules', []) %}
+    - {{ mod }}
+  {% endfor %}
+{% elif 'publisher_acl_blacklist' in cfg_salt  %}
+publisher_acl_blacklist:
+  users:
+  {% for user in cfg_salt['publisher_acl_blacklist'].get('users', []) %}
+    - {{ user }}
+  {% endfor %}
+  modules:
+  {% for mod in cfg_salt['publisher_acl_blacklist'].get('modules', []) %}
+    - {{ mod }}
+  {% endfor %}
+{% elif 'client_acl_blacklist' in cfg_master %}
 {%- do default_keys.append('client_acl_blacklist') %}
 client_acl_blacklist:
   users:

--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -351,7 +351,7 @@ publisher_acl:
 {%- endfor -%}
 {% elif 'client_acl' in cfg_master -%}
 {%- do default_keys.append('client_acl') %}
-client_acl:
+publisher_acl:
 {%- for name, user in cfg_master['client_acl']|dictsort %}
   {{ name}}:
 {%- for command in user %}
@@ -359,7 +359,7 @@ client_acl:
 {%- endfor -%}
 {%- endfor -%}
 {% elif 'client_acl' in cfg_salt -%}
-client_acl:
+publisher_acl:
 {%- for name, user in cfg_salt['client_acl']|dictsort %}
   {{ name }}:
 {%- for command in user %}
@@ -401,7 +401,7 @@ publisher_acl_blacklist:
   {% endfor %}
 {% elif 'client_acl_blacklist' in cfg_master %}
 {%- do default_keys.append('client_acl_blacklist') %}
-client_acl_blacklist:
+publisher_acl_blacklist:
   users:
   {% for user in cfg_master['client_acl_blacklist'].get('users', []) %}
     - {{ user }}
@@ -411,7 +411,7 @@ client_acl_blacklist:
     - {{ mod }}
   {% endfor %}
 {% elif 'client_acl_blacklist' in cfg_salt  %}
-client_acl_blacklist:
+publisher_acl_blacklist:
   users:
   {% for user in cfg_salt['client_acl_blacklist'].get('users', []) %}
     - {{ user }}
@@ -421,7 +421,7 @@ client_acl_blacklist:
     - {{ mod }}
   {% endfor %}
 {% else %}
-#client_acl_blacklist:
+#publisher_acl_blacklist:
 #  users:
 #    - root
 #    - '^(?!sudo_).*$'   #  all non sudo users
@@ -429,7 +429,7 @@ client_acl_blacklist:
 #    - cmd
 {% endif %}
 
-# Enforce client_acl & client_acl_blacklist when users have sudo
+# Enforce publisher_acl & publisher_acl_blacklist when users have sudo
 # access to the salt command.
 {{ get_config('sudo_acl', 'False') }}
 


### PR DESCRIPTION
To avoid log flooding with deprecation messages I moved to publisher_acl in salt master config. This PR makes the formula deal with it while it still works with client_acl option.