### PR TITLE
add salt master config template external_auth settings

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -401,7 +401,19 @@ client_acl_blacklist:
 #  pam:
 #    fred:
 #      - test.*
-{{ get_config('external_auth', '{}') }}
+{%- if 'external_auth' in cfg_master %}
+{%- do default_keys.append('external_auth') %}
+external_auth:
+{%- for auth, users in cfg_master['external_auth']|dictsort %}
+  {{ auth }}:
+{%- for user, commands in users.iteritems() %}
+    {{ user }}:
+{%- for command in commands %}
+      - {% raw %}'{% endraw %}{{ command }}{% raw %}'{% endraw %}
+{%- endfor -%}
+{%- endfor -%}
+{%- endfor -%}
+{%- endif %}
 
 # Time (in seconds) for a newly generated token to live. Default: 12 hours
 {{ get_config('token_expire', '43200') }}


### PR DESCRIPTION
With this formula it was not possible to add external_auth settings because the pillar was not parsed properly. This is what's changed with this PR.