### PR TITLE
Fix rendering of external_auth config.

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -511,7 +511,34 @@ external_auth:
 {%- for user, commands in users.iteritems() %}
     {{ user }}:
 {%- for command in commands %}
+{%- if command is mapping %}
+{%- for target, targetcommands in command.iteritems() %}
+      - {% raw %}'{% endraw %}{{ target }}{% raw %}'{% endraw %}:
+{%- for targetcommand in targetcommands %}
+{%- if targetcommand is mapping %}
+{%- for module, options in targetcommand.iteritems() %}
+        - {% raw %}'{% endraw %}{{ module }}{% raw %}'{% endraw %}:
+{%- for category, arguments in options.iteritems() %}
+            {% raw %}'{% endraw %}{{ category }}{% raw %}'{% endraw %}:
+{%- if arguments is mapping %}
+{%- for key, argument in arguments.iteritems() %}
+              {% raw %}'{% endraw %}{{ key }}{% raw %}'{% endraw %}: {% raw %}'{% endraw %}{{ argument }}{% raw %}'{% endraw %}
+{%- endfor %}
+{%- else %}
+{%- for argument in arguments %}
+              - {% raw %}'{% endraw %}{{ argument }}{% raw %}'{% endraw %}
+{%- endfor %}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+{%- else %}
+        - {% raw %}'{% endraw %}{{ targetcommand }}{% raw %}'{% endraw %}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+{%- else %}
       - {% raw %}'{% endraw %}{{ command }}{% raw %}'{% endraw %}
+{%- endif %}
 {%- endfor -%}
 {%- endfor -%}
 {%- endfor -%}


### PR DESCRIPTION
Currently the code stumbles over these definitions:

per user, per minion
```
external_auth:
  pam:
    thatch:
      - 'web*':
        - test.*
        - network.*
```

function argument limiting
```
external_auth:
  pam:
    my_user:
      - '*':
        - 'my_mod.*':
            args:
            - 'a.*'
            - 'b.*'
            kwargs:
              'kwa': 'kwa.*'
              'kwb': 'kwb'
```