### PR TITLE
Allow to specify reactors separatedly for master and minions

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -95,6 +95,13 @@ salt:
             type: runner
             cmd: jobs.list_jobs
 
+    # optional: these reactors will be configured on the master
+    # They override reactors configured in
+    # 'salt:reactors' or the old 'salt:reactor' parameters
+    reactors:
+      - 'master/deploy':
+      - /srv/salt/reactors/deploy.sls
+
   # salt minion config:
   minion:
 
@@ -171,6 +178,12 @@ salt:
           - 1.0
         interval: 10
 
+    # Optional reactors: these reactors will be configured on the minion
+    # They override reactors configured in
+    # 'salt:reactors' or the old 'salt:reactor' parameters
+    reactors:
+      - 'master/deploy':
+      - /srv/salt/reactors/deploy.sls
 
   # salt cloud config
   cloud:
@@ -229,9 +242,7 @@ salt:
       - IAD
       - SYD
       - HKG
-  reactor:
-    - 'deploy':
-      - /srv/salt/reactors/deploy.sls
+
   ssh_roster:
     prod1:
       host: host.example.com
@@ -248,6 +259,11 @@ salt:
           -----END RSA PRIVATE KEY-----
         pub: |
           ...........
+
+  # These reactors will be configured both to the minion and the master
+  reactors:
+    - 'deploy':
+      - /srv/salt/reactors/deploy.sls
 
 salt_cloud_certs:
   aws:

--- a/pillar.example
+++ b/pillar.example
@@ -182,7 +182,7 @@ salt:
     # They override reactors configured in
     # 'salt:reactors' or the old 'salt:reactor' parameters
     reactors:
-      - 'master/deploy':
+      - 'minion/deploy':
       - /srv/salt/reactors/deploy.sls
 
   # salt cloud config
@@ -260,7 +260,7 @@ salt:
         pub: |
           ...........
 
-  # These reactors will be configured both to the minion and the master
+  # These reactors will be configured both in the minion and the master
   reactors:
     - 'deploy':
       - /srv/salt/reactors/deploy.sls

--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -1,6 +1,6 @@
 # This file managed by Salt, do not edit by hand!!
 # Based on salt version 2016.11 default config
-{% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs', 'engines', 'lxc.network_profile', 'lxc.container_profile'] -%}
+{% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs', 'engines', 'lxc.network_profile', 'lxc.container_profile', 'reactors'] -%}
 {% set cfg_salt = pillar.get('salt', {}) -%}
 {% set cfg_master = cfg_salt.get('master', {}) -%}
 {% set default_keys = [] -%}

--- a/salt/files/master.d/reactor.conf
+++ b/salt/files/master.d/reactor.conf
@@ -2,7 +2,7 @@
 # This file is managed by Salt! Do not edit by hand!
 #
 {# The parameter reactor is kept for backward compatibility -#}
-{%- set reactors = salt['pillar.get']('salt:reactor') -%}
+{%- set reactors = salt['pillar.get']('salt:reactor', []) -%}
 {%- set reactors = salt['pillar.get']('salt:reactors', default=reactors, merge=True) -%}
 {%- set reactors = salt['pillar.get']('salt:master:reactors', default=reactors, merge=True) -%}
 

--- a/salt/files/master.d/reactor.conf
+++ b/salt/files/master.d/reactor.conf
@@ -1,7 +1,11 @@
 #
 # This file is managed by Salt! Do not edit by hand!
 #
+{# The parameter reactor is kept for backward compatibility -#}
 {%- set reactors = salt['pillar.get']('salt:reactor') -%}
+{%- set reactors = salt['pillar.get']('salt:reactors', default=reactors, merge=True) -%}
+{%- set reactors = salt['pillar.get']('salt:master:reactors', default=reactors, merge=True) -%}
+
 {%- if reactors %}
 reactor:
   {%- for reactor in reactors %}

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -1,7 +1,7 @@
 # This file managed by Salt, do not edit by hand!!
 #  Based on salt version 2016.11 default config
 #
-{% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs', 'engines', 'beacons'] -%}
+{% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs', 'engines', 'beacons', 'reactors'] -%}
 {% set cfg_salt = pillar.get('salt', {}) -%}
 {% set cfg_minion = cfg_salt.get('minion', {}) -%}
 {% set default_keys = [] -%}

--- a/salt/files/minion.d/reactor.conf
+++ b/salt/files/minion.d/reactor.conf
@@ -2,7 +2,7 @@
 # This file is managed by Salt! Do not edit by hand!
 #
 {# The parameter reactor is kept for backward compatibility -#}
-{%- set reactors = salt['pillar.get']('salt:reactor') -%}
+{%- set reactors = salt['pillar.get']('salt:reactor', []) -%}
 {%- set reactors = salt['pillar.get']('salt:reactors', default=reactors, merge=True) -%}
 {%- set reactors = salt['pillar.get']('salt:minion:reactors', default=reactors, merge=True) -%}
 

--- a/salt/files/minion.d/reactor.conf
+++ b/salt/files/minion.d/reactor.conf
@@ -1,7 +1,11 @@
 #
 # This file is managed by Salt! Do not edit by hand!
 #
+{# The parameter reactor is kept for backward compatibility -#}
 {%- set reactors = salt['pillar.get']('salt:reactor') -%}
+{%- set reactors = salt['pillar.get']('salt:reactors', default=reactors, merge=True) -%}
+{%- set reactors = salt['pillar.get']('salt:minion:reactors', default=reactors, merge=True) -%}
+
 {%- if reactors %}
 reactor:
   {%- for reactor in reactors %}


### PR DESCRIPTION
Changed variable name to `reactors`, to be similar to other variables (beacons, engines, etc) and excluded them from the `f_defaults.conf` file