### PR TITLE
Fix master_tops configuration rendering

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -746,14 +746,21 @@ rosters:
 {%- do default_keys.append('master_tops') %}
 master_tops:
 {%- for master in cfg_master['master_tops'] -%}
-  {%- if cfg_master['master_tops'][master] is string %}
-  {{ master }}: {{ cfg_master['master_tops'][master] }}
-  {%- else %}
-  {{ master}}:
+  {%- if cfg_master['master_tops'][master] is mapping %}
+  {{ master }}:
     {%- for parameter in cfg_master['master_tops'][master] %}
     {{ parameter }}: {{ cfg_master['master_tops'][master][parameter] }}
     {%- endfor -%}
-  {%- endif -%}
+  {%- elif cfg_master['master_tops'][master] is string %}
+  {{ master }}: {{ cfg_master['master_tops'][master] }}
+  {%- elif cfg_master['master_tops'][master] is iterable %}
+  {{ master }}:
+    {%- for item in cfg_master['master_tops'][master] %}
+      - {{ item }}
+    {%- endfor -%}
+  {%- else %}
+  {{ master }}: {{ cfg_master['master_tops'][master] }}
+  {% endif %}
 {%- endfor %}
 {% endif %}
 


### PR DESCRIPTION
When you add a custom master top to the saltmaster configuration the master.sls state will fail if the config looks like:
```
master_tops:
  customtop: True
```
This happens because it wil not treat the situation when you have a boolean as a value for the customtop.

See also:
https://docs.saltstack.com/en/latest/topics/master_tops/index.html

My change consists in checking for all possible values and apply the state accordingly.