### PR TITLE
add a way to set which release of saltstack to use

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -22,6 +22,12 @@ salt:
     salt-cloud: 'salt-cloud'
     salt-ssh: 'salt-ssh'
 
+  # Set which release of SaltStack to use, default to 'latest'
+  # To get the available releases:
+  # * http://repo.saltstack.com/yum/redhat/7/x86_64/
+  # * http://repo.saltstack.com/apt/debian/8/amd64/
+  release: 2016.11
+
   # salt master config
   master:
     fileserver_backend:

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -62,8 +62,8 @@ that differ from whats in defaults.yaml
       },
     },
     'RedHat':  {
-      'pkgrepo': 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/' + salt_release
-      'key_url': 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/' + salt_release + '/SALTSTACK-GPG-KEY.pub'
+      'pkgrepo': 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/' + salt_release,
+      'key_url': 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/' + salt_release + '/SALTSTACK-GPG-KEY.pub',
       'pygit2': salt['grains.filter_by']({
         'Fedora': 'python2-pygit2',
         'default': 'python-pygit2',

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -40,11 +40,12 @@ Setup variable using grains['os_family'] based logic, only add key:values here
 that differ from whats in defaults.yaml
 ##}
 {% set osrelease = salt['grains.get']('osrelease') %}
+{% set salt_release = salt['pillar.get']('salt:release', 'latest') %}
 {% set os_family_map = salt['grains.filter_by']({
     'Debian':  {
       'pkgrepo': 'deb http://repo.saltstack.com/apt/' +
-      salt['grains.get']('os')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/amd64/latest ' + salt['grains.get']('oscodename') + ' main',
-      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/amd64/latest/SALTSTACK-GPG-KEY.pub',
+      salt['grains.get']('os')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/amd64/' + salt_release + ' ' + salt['grains.get']('oscodename') + ' main',
+      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/amd64/' + salt_release  + '/SALTSTACK-GPG-KEY.pub',
       'libgit2': 'libgit2-22',
       'gitfs': {
         'pygit2': {
@@ -61,6 +62,8 @@ that differ from whats in defaults.yaml
       },
     },
     'RedHat':  {
+      'pkgrepo': 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/' + salt_release
+      'key_url': 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/' + salt_release + '/SALTSTACK-GPG-KEY.pub'
       'pygit2': salt['grains.filter_by']({
         'Fedora': 'python2-pygit2',
         'default': 'python-pygit2',
@@ -142,8 +145,8 @@ that differ from whats in defaults.yaml
   }, merge=salt['grains.filter_by']({
     'Ubuntu':  {
       'pkgrepo': 'deb http://repo.saltstack.com/apt/' +
-      salt['grains.get']('os')|lower + '/' + osrelease + '/amd64/latest ' + salt['grains.get']('oscodename') + ' main',
-      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os')|lower + '/' + osrelease + '/amd64/latest/SALTSTACK-GPG-KEY.pub',
+      salt['grains.get']('os')|lower + '/' + osrelease + '/amd64/' + salt_release  + ' ' + salt['grains.get']('oscodename') + ' main',
+      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os')|lower + '/' + osrelease + '/amd64/' + salt_release + '/SALTSTACK-GPG-KEY.pub',
       'pygit2': 'python-pygit2',
       'gitfs': {
         'pygit2': {
@@ -157,8 +160,8 @@ that differ from whats in defaults.yaml
     },
     'Raspbian': {
       'pkgrepo': 'deb http://repo.saltstack.com/apt/' +
-      salt['grains.get']('os_family')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/armhf/latest ' + salt['grains.get']('oscodename') + ' main',
-      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os_family')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/armhf/latest/SALTSTACK-GPG-KEY.pub',
+      salt['grains.get']('os_family')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/armhf/' + salt_release + ' ' + salt['grains.get']('oscodename') + ' main',
+      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os_family')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/armhf/' + salt_release + '/SALTSTACK-GPG-KEY.pub',
     },
     'SmartOS': {
       'salt_master': 'salt',

--- a/salt/pkgrepo/redhat/init.sls
+++ b/salt/pkgrepo/redhat/init.sls
@@ -3,7 +3,7 @@
 saltstack-pkgrepo:
   pkgrepo.managed:
     - humanname: SaltStack repo for RHEL/CentOS $releasever
-    - baseurl: https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest
+    - baseurl: {{ salt_settings.pkgrepo }}
     - enabled: 1
     - gpgcheck: 1
-    - gpgkey: https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest/SALTSTACK-GPG-KEY.pub
+    - gpgkey: {{ salt_settings.key_url }}


### PR DESCRIPTION
SaltStack provides "versioned" repositories, this commit add a way
to set which release of salt to use.

It adds a pillar "salt:release" which can be set to a specific release
(ex: 2016.11). This release is then used to configure properly the
repositories URLs for Debian/Ubuntu/RedHat.

The default behavior is to point to 'latest', retaining the previous
behavior if the "salt:release" pillar is not set.

Related to https://github.com/saltstack-formulas/salt-formula/issues/293