### PR TITLE
Remove "source" comments from Saltify configs

### DIFF
--- a/salt/files/cloud.maps.d/_saltify.conf
+++ b/salt/files/cloud.maps.d/_saltify.conf
@@ -1,4 +1,4 @@
-# This file is managed by Salt
+# This file is managed by Salt! Do not edit by hand!
 make_salty:
   - someinstance:
       ssh_host: somehost.somedomain

--- a/salt/files/cloud.maps.d/_saltify.conf
+++ b/salt/files/cloud.maps.d/_saltify.conf
@@ -1,4 +1,4 @@
-# This file is managed by Salt via {{ source }}
+# This file is managed by Salt
 make_salty:
   - someinstance:
       ssh_host: somehost.somedomain

--- a/salt/files/cloud.profiles.d/_saltify.conf
+++ b/salt/files/cloud.profiles.d/_saltify.conf
@@ -1,3 +1,3 @@
-# This file is managed by Salt via {{ source }}
+# This file is managed by Salt
 make_salty:
   provider: saltify

--- a/salt/files/cloud.profiles.d/_saltify.conf
+++ b/salt/files/cloud.profiles.d/_saltify.conf
@@ -1,3 +1,3 @@
-# This file is managed by Salt
+# This file is managed by Salt! Do not edit by hand!
 make_salty:
   provider: saltify

--- a/salt/files/cloud.providers.d/_saltify.conf
+++ b/salt/files/cloud.providers.d/_saltify.conf
@@ -1,4 +1,4 @@
-# This file is managed by Salt via {{ source }}
+# This file is managed by Salt
 
 {% set cloud = salt['pillar.get']('salt:cloud', {}) -%}
 

--- a/salt/files/cloud.providers.d/_saltify.conf
+++ b/salt/files/cloud.providers.d/_saltify.conf
@@ -1,4 +1,4 @@
-# This file is managed by Salt
+# This file is managed by Salt! Do not edit by hand!
 
 {% set cloud = salt['pillar.get']('salt:cloud', {}) -%}
 


### PR DESCRIPTION
I use Salt environments to provide each of my team mates the ability to develop
and test their Salt changes. And I've found that when we run this formula from
our environments against our salt-master, comments in some files change. For us
this represents an unwanted and unplanned change. I understand the intention -
to identify whow or why the file changed, but I firmly believe that we should
be able to run highstsate with test=True and only see intended changes. Here's
an example:

            ID: salt-cloud-providers
      Function: file.recurse
          Name: /etc/salt/cloud.providers.d
        Result: None
       Comment: #### /etc/salt/cloud.providers.d/saltify.conf ####
                The file /etc/salt/cloud.providers.d/saltify.conf is set to be changed
       Started: 20:01:28.586441
      Duration: 75.185 ms
       Changes:
                ----------
                /etc/salt/cloud.providers.d/saltify.conf:
                    ----------
                    diff:
                        ---
                        +++
                        @@ -1,4 +1,4 @@
                        -# This file is managed by Salt via salt://salt/files/cloud.providers.d/saltify.conf?saltenv=myenv
                        +# This file is managed by Salt via salt://salt/files/cloud.providers.d/saltify.conf?saltenv=dev

                         saltify:
                           provider: saltify