### PR TITLE
Add restart minion via at (fixes #136)

### DIFF
--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -4,6 +4,7 @@ salt:
   install_packages: True
   use_pip: False
   clean_config_d_dir: True
+  restart_via_at: False
 
   config_path: /etc/salt
 

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -31,7 +31,7 @@ restart-salt-minion:
   cmd.wait:
     - name: echo salt-call --local service.restart salt-minion | at now + 1 minute
     - order: last
-    - reqiure:
+    - require:
         - pkg: at
     - watch:
   {%- if salt_settings.install_packages %}


### PR DESCRIPTION
This PR addresses issue #136 and adds possibility to restart salt minion via at. This is fully optional and disabled by default to preserve backwards  compatibility.