### PR TITLE
Set clean_config_d_dir to False by default

### DIFF
--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -3,7 +3,7 @@
 salt:
   install_packages: True
   use_pip: False
-  clean_config_d_dir: True
+  clean_config_d_dir: False
 
   config_path: /etc/salt
 


### PR DESCRIPTION
pillar example says : 

```
  # Set this to true to clean any non-salt-formula managed files out of
  # /etc/salt/{master,minion}.d ... You really don't want to do this on 2015.2
  # and up as it'll wipe out important files that Salt relies on.
  clean_config_d_dir: False
```

This leads me to believe that the default should be False. Am I missing something ?