### PR TITLE
Fix map.jinja to work with 2017.7.0

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -44,8 +44,8 @@ that differ from whats in defaults.yaml
 {% set os_family_map = salt['grains.filter_by']({
     'Debian':  {
       'pkgrepo': 'deb http://repo.saltstack.com/apt/' +
-      salt['grains.get']('os')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/amd64/' + salt_release + ' ' + salt['grains.get']('oscodename') + ' main',
-      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/amd64/' + salt_release  + '/SALTSTACK-GPG-KEY.pub',
+      salt['grains.get']('os')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease)|string + '/amd64/' + salt_release + ' ' + salt['grains.get']('oscodename') + ' main',
+      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease)|string + '/amd64/' + salt_release  + '/SALTSTACK-GPG-KEY.pub',
       'libgit2': 'libgit2-22',
       'gitfs': {
         'pygit2': {
@@ -160,8 +160,8 @@ that differ from whats in defaults.yaml
     },
     'Raspbian': {
       'pkgrepo': 'deb http://repo.saltstack.com/apt/' +
-      salt['grains.get']('os_family')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/armhf/' + salt_release + ' ' + salt['grains.get']('oscodename') + ' main',
-      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os_family')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/armhf/' + salt_release + '/SALTSTACK-GPG-KEY.pub',
+      salt['grains.get']('os_family')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease)|string + '/armhf/' + salt_release + ' ' + salt['grains.get']('oscodename') + ' main',
+      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os_family')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease)|string + '/armhf/' + salt_release + '/SALTSTACK-GPG-KEY.pub',
     },
     'SmartOS': {
       'salt_master': 'salt',


### PR DESCRIPTION
This was to resolve the following error when using this state on `2017.7.0` (with the [change to osmajorrelease](https://docs.saltstack.com/en/develop/topics/releases/nitrogen.html#grains-changes):

```
local:
    Data failed to compile:
----------
    Rendering SLS 'base:salt.master' failed: Jinja error: coercing to Unicode: need string or buffer, int found
/var/cache/salt/minion/files/base/salt/map.jinja(44):
---
[...]
Setup variable using grains['os_family'] based logic, only add key:values here
that differ from whats in defaults.yaml
##}
{% set osrelease = salt['grains.get']('osrelease') %}
{% set salt_release = salt['pillar.get']('salt:release', 'latest') %}
{% set os_family_map = salt['grains.filter_by']({    <======================
    'Debian':  {
      'pkgrepo': 'deb http://repo.saltstack.com/apt/' +
      salt['grains.get']('os')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/amd64/' + salt_release + ' ' + salt['grains.get']('oscodename') + ' main',
      'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease) + '/amd64/' + salt_release  + '/SALTSTACK-GPG-KEY.pub',
      'libgit2': 'libgit2-22',
[...]
---
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/utils/templates.py", line 410, in render_jinja_tmpl
    output = template.render(**decoded_context)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 1, in top-level template code
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 1033, in make_module
    return TemplateModule(self, self.new_context(vars, shared, locals))
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 1090, in __init__
    self._body_stream = list(template.root_render_func(context))
  File "/var/cache/salt/minion/files/base/salt/map.jinja", line 44, in top-level template code
    {% set os_family_map = salt['grains.filter_by']({
TypeError: coercing to Unicode: need string or buffer, int found
```

This has not been tested with earlier salt versions, but I don't see any issue with it.