### PR TITLE
Enable option to set minion scheduler

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -150,6 +150,13 @@ salt:
     mine_functions:
       network.interface_ip: [eth0]
 
+    # Define a minion scheduler
+    schedule:
+      - highstate:
+        - function: state.apply
+        - minutes: 60
+        - returner: redis
+
     # other 'non-default' config
     auth_keytab: /root/auth.keytab
     auth_principal: kadmin/admin

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -370,6 +370,27 @@ mine_functions:
 # second on the minion scheduler.
 {{ get_config('loop_interval', '1') }}
 
+
+# When using the scheduler at least one schedule needs to be
+# defined. The user running the salt master will need read access to the repo.
+{% if 'schedule' in cfg_minion -%}
+{%- do default_keys.append('schedule') %}
+schedule:
+{%- for schedule in cfg_minion['schedule'] %}
+{%- if schedule is iterable and schedule is not string %}
+  {%- for name, children in schedule.items() %}
+    {{ name }}:
+  {%- for child in children %}
+    {%- for key, value in child.items() %}
+      {{ key }}: {{ value }}
+    {%- endfor -%}
+  {%- endfor -%}
+  {%- endfor -%}
+{%- endif -%}
+{%- endfor -%}
+{%- endif %}
+
+
 # Some installations choose to start all job returns in a cache or a returner
 # and forgo sending the results back to a master. In this workflow, jobs
 # are most often executed with --async from the Salt CLI and then results


### PR DESCRIPTION
Tested on CentOS 7

An example:
```
minion:
  schedule:
    - highstate:
      - function: state.apply
      - minutes: 60
      - returner: redis
```

Would result to:
```
schedule:
    highstate:
      function: state.apply
      minutes: 60
      returner: redis
```