### PR TITLE
fix #296 deprecated iteritems() and replace it with items()

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -5,7 +5,7 @@
 {#-     This whole `'dict' in x.__class__.__name__` mess is a 
         workaround for the missing mapping test in CentOS 6's 
         ancient Jinja2, see #193  #}
-{%-     for k,v in b.iteritems() %}
+{%-     for k,v in b.items() %}
 {%-         if v is string or v is number %}
 {%-             do a.update({ k: v }) %}
 {%-         elif 'dict' not in v.__class__.__name__ %}


### PR DESCRIPTION
Formulas iterating over dictionaries should use the items() method instead of iteritems() because the latter method has been removed from Python 3. While the items() method in Python 2 uses more memory than iteritems(), these dictionaries are typically small (e.g., sets of settings from Pillar).