### PR TITLE
Update f_defaults.conf to support elasticsearch returner

### DIFF
--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -1218,9 +1218,17 @@ return:
 #####   elasticsearch connection settings  #####
 ##########################################
 {%- for name, value in cfg_minion['elasticsearch'].items() %}
+{%- if value is list %}
+elasticsearch.{{ name }}:
+{%- for objvalue in value %}
+  - {{ objvalue }}
+{%- endfor %}
+{%- else %}
 elasticsearch.{{ name }}: {{ value }}
+{%- endif %}les
 {%- endfor %}
 {%- endif %}
+
 
 {% if 'mongo' in cfg_minion -%}
 {%- do default_keys.append('mongo') %}

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -1212,6 +1212,16 @@ return:
 #event_match_type: startswith
 {{ get_config('event_match_type', 'startswith') }}
 
+{% if 'elasticsearch' in cfg_minion -%}
+{%- do default_keys.append('elasticsearch') %}
+{%- do default_keys.append('return') %}
+#####   elasticsearch connection settings  #####
+##########################################
+{%- for name, value in cfg_minion['elasticsearch'].items() %}
+elasticsearch.{{ name }}: {{ value }}
+{%- endfor %}
+{%- endif %}
+
 {% if 'mongo' in cfg_minion -%}
 {%- do default_keys.append('mongo') %}
 #####   mongodb connection settings  #####

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -1225,7 +1225,7 @@ elasticsearch.{{ name }}:
 {%- endfor %}
 {%- else %}
 elasticsearch.{{ name }}: {{ value }}
-{%- endif %}les
+{%- endif %}
 {%- endfor %}
 {%- endif %}
 


### PR DESCRIPTION
This is a proposed change that we (UW IHME) have been using in production for a few weeks, and a needed deviation from the master branch of the salt-formula

This is reasonably simple, by detecting minion pillar data with elasticsearch configuration for the returner, and spits out the necessary YAML.

Example pillar:
```
      elasticsearch:
            ----------
            functions_blacklist:
                - test.ping
                - saltutil.findjob
                - pillar.items
                - grains.items
            hosts:
                - 10.0.0.1:9200
                - 10.0.0.2:9200
                - 10.0.0.3:9200
                - 10.0.0.4:9200
                - 10.0.0.5:9200
            index_date:
                True
            number_of_replicas:
                1
            number_of_shards:
                5
            states_count:
                True
            states_order_output:
                True
            states_single_index:
                True
```


Example output: 

```
#####   elasticsearch connection settings  #####
##########################################
elasticsearch.number_of_replicas: 1
elasticsearch.states_order_output: True
elasticsearch.states_count: True
elasticsearch.number_of_shards: 5
elasticsearch.states_single_index: True
elasticsearch.index_date: True
elasticsearch.hosts:
  - 10.0.0.1:9200
  - 10.0.0.2:9200
  - 10.0.0.3:9200
  - 10.0.0.4:9200
  - 10.0.0.5:9200
elasticsearch.functions_blacklist: 
  - test.ping
  - saltutil.findjob
  - pillar.items
  - grains.items
```