### PR TITLE
Set correct api_service for SmartOS

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -190,6 +190,7 @@ that differ from whats in defaults.yaml
       'salt_ssh': 'salt',
       'minion_service': 'salt:minion',
       'master_service': 'salt:master',
+      'api_service': 'salt:api',
       'python_dulwich': 'py27-dulwich',
       'gitfs': {
         'dulwich': {


### PR DESCRIPTION
On SmartOS the salt-api daemon is started by the salt:api service.