### PR TITLE
Quotation and ipv6

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -892,44 +892,44 @@ master_tops:
 # For example, if you manage your custom modules and states in subversion
 # and don't want all the '.svn' folders and content synced to your minions,
 # you could set this to '/\.svn($|/)'. By default nothing is ignored.
-{% if 'file_ignore_regex' in cfg_master %}
+{%- if 'file_ignore_regex' in cfg_master %}
 {%- do default_keys.append('file_ignore_regex') %}
 file_ignore_regex:
-  {% for regex in cfg_master['file_ignore_regex'] %}
+  {%- for regex in cfg_master['file_ignore_regex'] %}
   - {{ regex }}
-  {% endfor %}
-{% elif 'file_ignore_regex' in cfg_salt %}
+  {%- endfor %}
+{%- elif 'file_ignore_regex' in cfg_salt %}
 file_ignore_regex:
-  {% for regex in cfg_salt['file_ignore_regex'] %}
+  {%- for regex in cfg_salt['file_ignore_regex'] %}
   - {{ regex }}
-  {% endfor %}
-{% else %}
+  {%- endfor %}
+{%- else %}
 #file_ignore_regex:
 #  - '/\.svn($|/)'
 #  - '/\.git($|/)'
-{% endif %}
+{%- endif %}
 
 # A file glob (or list of file globs) that will be matched against the file
 # path before syncing the modules and states to the minions. This is similar
 # to file_ignore_regex above, but works on globs instead of regex. By default
 # nothing is ignored.
-{% if 'file_ignore_glob' in cfg_master %}
+{%- if 'file_ignore_glob' in cfg_master %}
 {%- do default_keys.append('file_ignore_glob') %}
 file_ignore_glob:
-  {% for glob in cfg_master['file_ignore_glob'] %}
-  - {{ glob }}
-  {% endfor %}
-{% elif 'file_ignore_glob' in cfg_salt %}
+  {%- for glob in cfg_master['file_ignore_glob'] %}
+  - '{{ glob }}'
+  {%- endfor %}
+{%- elif 'file_ignore_glob' in cfg_salt %}
 file_ignore_glob:
-  {% for glob in cfg_salt['file_ignore_glob'] %}
-  - {{ glob }}
-  {% endfor %}
-{% else %}
+  {%- for glob in cfg_salt['file_ignore_glob'] %}
+  - '{{ glob }}'
+  {%- endfor %}
+{%- else %}
 # file_ignore_glob:
 #  - '*.pyc'
 #  - '*/somefolder/*.bak'
 #  - '*.swp'
-{% endif %}
+{%- endif %}
 
 # File Server Backend
 #

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -41,6 +41,9 @@ master:
 {{ get_config('master', 'salt') }}
 {%- endif %}
 
+# Set whether the minion should connect to the master via IPv6:
+{{ get_config('ipv6', 'False') }}
+
 # Set http proxy information for the minion when doing requests
 {% if 'proxy_host' in cfg_minion -%}
 {%- do default_keys.append('proxy_host') %}


### PR DESCRIPTION
1. I've added ipv6 option in minion config.
2. In master config:
  - I've added quotation in file_ignore_glob. Lack of quotation was causing pase error. 
  - some cleanup in template, to make compiled file looks nicer.