### PR TITLE
[Minion] [returner] [Elasticsearch] Yaml read patch + example.pillar update

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -202,6 +202,24 @@ salt:
       - 'minion/deploy':
         - /srv/salt/reactors/deploy.sls
 
+    # Optional: Configure an elasticsearch returner
+    return: elasticsearch
+    elasticsearch:
+      hosts:
+        - example.elasticsearch.host:9200
+        - example.elasticsearch.host2:9200
+      index_date: True
+      index: salt
+      number_of_shards: 5
+      number_of_replicas: 2
+      debug_returner_payload: True
+      states_count: True
+      states_order_output: True
+      states_single_index: True
+      functions_blacklist:
+        - test.ping
+        - saltutil.find_job
+
   # salt cloud config
   cloud:
     master: salt
@@ -332,3 +350,4 @@ salt_formulas:
       - salt-formula
       - postfix-formula
       - openssh-formula
+

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -1215,16 +1215,18 @@ return:
 {% if 'elasticsearch' in cfg_minion -%}
 {%- do default_keys.append('elasticsearch') %}
 {%- do default_keys.append('return') %}
+
 #####   elasticsearch connection settings  #####
 ##########################################
+elasticsearch:
 {%- for name, value in cfg_minion['elasticsearch'].items() %}
 {%- if value is list %}
-elasticsearch.{{ name }}:
+  {{ name }}:
 {%- for objvalue in value %}
-  - {{ objvalue }}
+    - {{ objvalue }}
 {%- endfor %}
 {%- else %}
-elasticsearch.{{ name }}: {{ value }}
+  {{ name }}: {{ value }}
 {%- endif %}
 {%- endfor %}
 {%- endif %}


### PR DESCRIPTION
The minion's returner isn't able to read the dot notation, the documentation is less-than-complete
Added whitespace and a parent key 'elasticsearch' to remediate, updated example.pillar