### PR TITLE
Issue 361

### DIFF
--- a/salt/gitfs/gitpython.sls
+++ b/salt/gitfs/gitpython.sls
@@ -1,5 +1,7 @@
 {% from "salt/map.jinja" import salt_settings with context %}
 
+{% if 'gitfs' in salt_settings and 'gitpython' in salt_settings.gitfs %}
+
 {% if salt_settings.gitfs.gitpython.install_from_source %}
 
 GitPython:
@@ -10,5 +12,7 @@ GitPython:
 python-git:
   pkg.installed:
     - name: {{ salt_settings.python_git }}
+
+{% endif %}
 
 {% endif %}

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -71,6 +71,9 @@ that differ from whats in defaults.yaml
       }, grain='os'),
       'python_git': 'GitPython',
       'gitfs': {
+        'gitpython': {
+          'install_from_source': False,
+        },
         'pygit2': {
           'install_from_source': False,
           'git': {


### PR DESCRIPTION
salt.gitfs.gitpython in defaults.yaml appears to be lost as part of the deep merge
This pull request adds a quick sanity check in the gitpython state to ensure salt.gitfs.gitpython pillar level exists in order to test boolean value salt_settings.gitfs.gitpython.install_from_source; salt will failt to render the state otherwise.

Also adds default value salt.gitfs.gitpython.install_from_source == False for RedHat os_family grain'ed minions via map.jinja. If the deep merge/defaults.yaml issue can't be fixed other O/S'es should probably have an appropriate default value set in map.jinja also.