### PR TITLE
Add MacOS support; fix Issue #352

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,3 +148,22 @@ Executing the provided `Vagrantfile <http://www.vagrantup.com/>`_  will create a
 The folders inside the VM will be set up in a way that enables you to simply execute 'sudo salt "*" state.highstate' to apply the salt formula to the VM, using the pillar.example config. You can check /etc/salt/ for results.
 
 Remember, you will have to run ``state.highstate`` or ``state.sls salt.(master|minion|cloud)`` manually.
+
+``MacOS Support``
+=================
+
+As MacOS has no native package management that pkg.installed can leverage appropriately, and brew does not count, the salt.minion formula manages salt minion package upgrades by way of .pkg file download which is then installed using the macpackage.installed state.
+
+salt-minion packages on MacOS will not upgraded by default. To enable package management you must set the following at a minimum,
+
+::
+
+    install_packages: True
+    version: 2017.7.4
+    salt_minion_pkg_source: https://repo.saltstack.com/osx/salt-2017.7.4-py3-x86_64.pkg
+
+install_packages must indicate that the installation of a package is desired. If so, version will be used to compare the version of the installed .pkg against the downloaded one. If version is not set and a salt.pkg is already installed the .pkg will not be installed again.
+
+A future update to the formula may include extraction of version from the downloaded .pkg itself; but for the time being you MUST set version to indicate what you believe it to be.
+
+Refer to pillar.example for more information.

--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ Remember, you will have to run ``state.highstate`` or ``state.sls salt.(master|m
 
 As MacOS has no native package management that pkg.installed can leverage appropriately, and brew does not count, the salt.minion state  manages salt minion package upgrades by way of .pkg file download which is then installed using the macpackage.installed state.
 
-salt-minion packages on MacOS will not upgraded by default. To enable package management you must set the following at a minimum,
+salt-minion packages on MacOS will not be upgraded by default. To enable package management you must set the following at a minimum,
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ Remember, you will have to run ``state.highstate`` or ``state.sls salt.(master|m
 ``MacOS Support``
 =================
 
-As MacOS has no native package management that pkg.installed can leverage appropriately, and brew does not count, the salt.minion formula manages salt minion package upgrades by way of .pkg file download which is then installed using the macpackage.installed state.
+As MacOS has no native package management that pkg.installed can leverage appropriately, and brew does not count, the salt.minion state  manages salt minion package upgrades by way of .pkg file download which is then installed using the macpackage.installed state.
 
 salt-minion packages on MacOS will not upgraded by default. To enable package management you must set the following at a minimum,
 

--- a/pillar.example
+++ b/pillar.example
@@ -31,6 +31,16 @@ salt:
   # * http://repo.saltstack.com/yum/redhat/7/x86_64/
   # * http://repo.saltstack.com/apt/debian/8/amd64/
   release: "2016.11"
+  
+  # MacOS has no package management. 
+  # Instead, we use file.managed to download an appropriate .pkg file and macpackage.installed to install it
+  # 'version', if set (see above), will be used to check the .pkg version to determine if it should be installed
+  #
+  # NOTE: if 'version' is not set version comparison will not occur and the .pkg WILL NOT be installed if a salt
+  # .pkg is already installed
+  # NOTE: salt_minion_pkg_hash, if set, will be passed into file.managed's source_hash, use URL or hash string
+  salt_minion_pkg_source: 'https://repo.saltstack.com/osx/salt-2017.7.4-py3-x86_64.pkg'
+  salt_minion_pkg_hash: 'https://repo.saltstack.com/osx/salt-2017.7.4-py3-x86_64.pkg.md5'
 
   # salt master config
   master:

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -162,7 +162,7 @@ that differ from whats in defaults.yaml
     },
     'MacOS': {
       'salt_minion': 'com.saltstack.salt',
-      'salt_minion_pkg_source': 'https://repo.saltstack.com/osx/salt-' + salt_release + '-py2-x86_64.pkg',
+      'salt_minion_pkg_source': '',
       'salt_minion_pkg_hash': '',
       'config_path': '/private/etc/salt',
       'minion_service': 'com.saltstack.salt.minion',

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -1,12 +1,42 @@
 {% from "salt/map.jinja" import salt_settings with context %}
 
-{% if grains.os != "MacOS" %}
+{% if grains.os == 'MacOS' and salt_settings.salt_minion_pkg_source != '' and salt_settings.version != '' %}
+{# only download IF we know where to get the pkg from and if we know what version to check the current install (if installed) against #}
+{# e.g. don't download unless it appears as though we're about to try and upgrade the minion #}
+download-salt-minion:
+  file.managed:
+    - name: '/tmp/salt.pkg'
+    - source: {{ salt_settings.salt_minion_pkg_source }}
+    {% if salt_settings.salt_minion_pkg_hash != '' %}
+    - source_hash: {{ salt_settings.salt_minion_pkg_hash }}
+    {% else %}
+    - skip_verify: True
+    {% endif %}
+    - user: root
+    - group: wheel
+    - mode: 0644
+    - unless:
+      - '/opt/salt/bin/salt-minion --version | grep {{ salt_settings.version }}'
+    - require_in:
+      - macpackage: salt-minion
+{% endif %}
+
 salt-minion:
 {% if salt_settings.install_packages %}
+  {%- if grains.os == 'MacOS' and salt_settings.salt_minion_pkg_source != '' and salt_settings.version != '' %}
+  macpackage.installed:
+    - name: '/tmp/salt.pkg'
+    - target: /
+    {# macpackage.installed behaves weirdly with version_check; version_check detects difference but fails to actually complete install. #}
+    {# use force == True as workaround #}
+    - force: True
+    - version_check: /opt/salt/bin/salt-minion --version=.*{{ salt_settings.version }}.*
+  {%- else %}
   pkg.installed:
     - name: {{ salt_settings.salt_minion }}
   {%- if salt_settings.version is defined %}
     - version: {{ salt_settings.version }}
+  {%- endif %}
   {%- endif %}
 {% endif %}
   file.recurse:
@@ -45,23 +75,35 @@ salt-minion:
   {%- endif %}
     - onchanges:
   {%- if salt_settings.install_packages %}
+    {%- if grains.os == 'MacOS' %}
+      - macpackage: salt-minion
+    {%- else %}
       - pkg: salt-minion
+    {%- endif %}
   {%- endif %}
       - file: salt-minion
       - file: remove-old-minion-conf-file
 {%- else %}
+
+  {% if grains.os != 'MacOS' %}
+  {# MacOS has 'at' command; but there's no package to install #}
 at:
   pkg.installed: []
+  {% endif %}
 
 restart-salt-minion:
   cmd.run:
-    - name: echo salt-call --local service.restart salt-minion | at now + 1 minute
+    - name: echo salt-call --local service.restart {{ salt_settings.minion_service }} | at now + 1 minute
     - order: last
     - require:
         - pkg: at
     - onchanges:
   {%- if salt_settings.install_packages %}
+      {%- if grains.os == 'MacOS' %}
+      - macpackage: salt-minion
+      {%- else %}
       - pkg: salt-minion
+      {%- endif %}
   {%- endif %}
       - file: salt-minion
       - file: remove-old-minion-conf-file
@@ -88,4 +130,10 @@ remove-old-minion-conf-file:
   file.absent:
     - name: {{ salt_settings.config_path }}/minion.d/_defaults.conf
 
+{% if grains.os == 'MacOS' %}
+remove-macpackage-salt:
+  cmd.run:
+    - name: 'rm -f /tmp/salt.pkg'
+    - onchanges:
+      - macpackage: salt-minion
 {% endif %}

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -1,6 +1,6 @@
 {% from "salt/map.jinja" import salt_settings with context %}
 
-{% if grains.os == 'MacOS' and salt_settings.salt_minion_pkg_source != '' and salt_settings.version != '' %}
+{% if salt_settings.install_packages and grains.os == 'MacOS' and salt_settings.salt_minion_pkg_source != '' and salt_settings.version != '' %}
 {# only download IF we know where to get the pkg from and if we know what version to check the current install (if installed) against #}
 {# e.g. don't download unless it appears as though we're about to try and upgrade the minion #}
 download-salt-minion:


### PR DESCRIPTION
Add's MacOS support to minion; allowing upgrade of salt-minion's running on MacOS systems.

Tested on MacOS 10.13.3 in conjunction with Windows and Linux minions in order to test for non-MacOS minion state breakage. Windows/Linux/etc minion upgrades/config still behave as expected.

NOTE: A default value for salt_minion_pkg_source has been removed from map.jinja as 'salt_release' is no longer usable (due to repo.saltstack.com changes) as a way to generate a valid URL to download a .pkg file from. 

There are no sym/hard links on repo.saltstack.com permitting the use of 'latest' at present either. The decision to upgrade the minion by salt.minion state relies on explicit configuration defining .pkg source and version to utilise.

Users will to define salt.version, salt.salt_minion_pkg_source URL (and optionally salt.salt_minion_pkg_hash if verification is desired) in order to trigger down of the MacOS .pkg file and upgrade, e.g. the following pillar snippet as an example.

```
salt:
  release: "2017.7"
  version: "2017.7.4"
  install_packages: True
  {% if grains.os == 'Windows' %}
  salt_minion: 'salt-minion-py3'
  {% elif grains.os == 'MacOS' %}
  salt_minion_pkg_source: 'https://repo.saltstack.com/osx/salt-2017.7.4-py3-x86_64.pkg'
  {% endif %}
```