### PR TITLE
only set master_alive_interval once

### DIFF
--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -468,7 +468,7 @@ schedule:
 # master_alive_interval to the number of seconds to poll the masters for
 # connection events.
 #
-{{ get_config('master_alive_interval', '30') }}
+#{{ get_config('master_alive_interval', '30') }}
 
 # The minion can include configuration from other files. To enable this,
 # pass a list of paths to this option. The paths can be either relative or


### PR DESCRIPTION
The `master_alive_interval` is getting set twice in `/etc/salt/minion.d/f_defaults.conf` which is causing the issue reported in #367. This favors the first occurrence in the template.

closes #367