### PR TITLE
Handle pillar params with child params.

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -1168,7 +1168,18 @@ ext_pillar:
     {%- elif pillar[key] is iterable and 'dict' not in pillar[key].__class__.__name__ %}
   - {{ key }}:
       {%- for parameter in pillar[key] %}
+        {%- if parameter is iterable and parameter is not string %}
+        {%- for param, children in parameter.items() %}
+    - {{ param }}:
+          {%- for child in children %}
+            {%- for key, value in child.items() %}
+      - {{ key }}: {{ value }}
+            {%- endfor -%}
+          {%- endfor -%}
+        {%- endfor -%}
+        {%- else %}
     - {{ parameter }}
+        {%- endif %}
       {%- endfor -%}
     {#- Workaround for missing `is mapping` on CentOS 6, see #193: #}
     {%- elif 'dict' in pillar[key].__class__.__name__ and pillar[key] is not string %}

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -848,7 +848,18 @@ ext_pillar:
     {%- elif pillar[key] is iterable and 'dict' not in pillar[key].__class__.__name__ %}
   - {{ key }}:
       {%- for parameter in pillar[key] %}
+        {%- if parameter is iterable and parameter is not string %}
+        {%- for param, children in parameter.items() %}
+    - {{ param }}:
+          {%- for child in children %}
+            {%- for key, value in child.items() %}
+      - {{ key }}: {{ value }}
+            {%- endfor -%}
+          {%- endfor -%}
+        {%- endfor -%}
+        {%- else %}
     - {{ parameter }}
+        {%- endif %}
       {%- endfor -%}
     {#- Workaround for missing `is mapping` on CentOS 6, see #193: #}
     {%- elif 'dict' in pillar[key].__class__.__name__ and pillar[key] is not string %}


### PR DESCRIPTION
This PR aims to fix #371 - i.e that pillar parameters can also have their own 'child' parameters - e.g.:

```
ext_pillar:
  - git:
    - master http://example.com/foo.git:
      - mountpoint: /foo
      - env: custom
```

It's basically a copy of how the `gitfs_remotes` section in the templates does it.