### PR TITLE
Handle extra config where value is a list (minion)

### DIFF
--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -1250,6 +1250,13 @@ alternative.mongo.{{ name }}: {{ value }}
 
 {%- for configname in cfg_minion %}
 {%- if configname not in reserved_keys and configname not in default_keys %}
+  {%- if cfg_minion[configname] is string %}
 {{ configname }}: {{ cfg_minion[configname]|json }}
+  {%- elif cfg_minion[configname] is iterable %}
+{{ configname }}:
+    {%- for item in cfg_minion[configname] %}
+  - {{ item }}
+    {%- endfor -%}
+  {%- endif %}
 {%- endif %}
 {%- endfor %}


### PR DESCRIPTION
Fixes #374 to provide support for `use_superseded` and similar config opts in minions.

I haven't seen examples of lists in master extra config, or of nested dicts rather than lists - but it wouldn't be too difficult to extend this if there's a need.