### PR TITLE
Support publisher_acl minion-level commands

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -385,21 +385,46 @@ event_return_blacklist:
 # This setting should be treated with care since it opens up execution
 # capabilities to non root users. By default this capability is completely
 # disabled.
+#publisher_acl:
+#  larry:
+#    - test.ping
+#    - network.*
+#    - '*':
+#      - pkg.*
+#
 {% if 'publisher_acl' in cfg_master -%}
 {%- do default_keys.append('publisher_acl') %}
 publisher_acl:
-{%- for name, user in cfg_master['publisher_acl']|dictsort %}
-  {{ name}}:
-{%- for command in user %}
+{%- for user, commands in cfg_master['publisher_acl']|dictsort %}
+  {{ user }}:
+{%- for command in commands %}
+{%- if command is mapping %}
+{%- for target, targetcommands in command.items() %}
+    - {% raw %}'{% endraw %}{{ target }}{% raw %}'{% endraw %}:
+{%- for targetcommand in targetcommands %}
+      - {% raw %}'{% endraw %}{{ targetcommand }}{% raw %}'{% endraw %}
+{%- endfor -%}
+{%- endfor -%}
+{%- else %}
     - {% raw %}'{% endraw %}{{ command }}{% raw %}'{% endraw %}
+{%- endif %}
 {%- endfor -%}
 {%- endfor -%}
 {% elif 'publisher_acl' in cfg_salt -%}
 publisher_acl:
-{%- for name, user in cfg_salt['publisher_acl']|dictsort %}
-  {{ name }}:
-{%- for command in user %}
+{%- for user, commands in cfg_salt['publisher_acl']|dictsort %}
+  {{ user }}:
+{%- for command in commands %}
+{%- if command is mapping %}
+{%- for target, targetcommands in command.items() %}
+    - {% raw %}'{% endraw %}{{ target }}{% raw %}'{% endraw %}:
+{%- for targetcommand in targetcommands %}
+      - {% raw %}'{% endraw %}{{ targetcommand }}{% raw %}'{% endraw %}
+{%- endfor -%}
+{%- endfor -%}
+{%- else %}
     - {% raw %}'{% endraw %}{{ command }}{% raw %}'{% endraw %}
+{%- endif %}
 {%- endfor -%}
 {%- endfor -%}
 {% elif 'client_acl' in cfg_master -%}
@@ -420,11 +445,6 @@ publisher_acl:
 {%- endfor -%}
 {%- endfor -%}
 {% else -%}
-#publisher_acl:
-#  larry:
-#    - test.ping
-#    - network.*
-#
 {%- endif %}
 
 # Blacklist any of the following users or modules


### PR DESCRIPTION
Hello,

Here is an attempt to fix the issue reported in #376.

The code is a bit similar to the one used in the _external_auth_ section, and allows to support both types of entries thanks to the [jinja](http://jinja.pocoo.org/docs/2.10/) [mapping](http://jinja.pocoo.org/docs/2.10/templates/#mapping) test.

Feel free to comment.