### PR TITLE
Stop noise from 'test -e' check'

### DIFF
--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -51,7 +51,7 @@
     - require:
       - file: {{ basedir }}
     {%- if not update %}
-    - unless: test -e {{ gitdir }}
+    - unless: test -e {{ gitdir }} >/dev/null 2>&1
     {%- endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Salt prints noisy `[ERROR   ]` messages to **stdout** when `test -e <dir>` prints to **STDERR**.  
```
[ERROR   ] Command 'test -e /srv/formulas/openssh-formula' failed with return code: 1
[ERROR   ] retcode: 1
[ERROR   ] Command 'test -e /srv/formulas/packages-formula' failed with return code: 1
[ERROR   ] retcode: 1
[ERROR   ] Command 'test -e /srv/formulas/firewalld-formula' failed with return code: 1
[ERROR   ] retcode: 1
[ERROR   ] Command 'test -e /srv/formulas/etcd-formula' failed with return code: 1
[ERROR   ] retcode: 1
``` 

This PR redirects the output to /dev/null to get rid of the noise.
