### PR TITLE
Fix support for extra config values as mappings

### DIFF
--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -1255,7 +1255,7 @@ alternative.mongo.{{ name }}: {{ value }}
 
 {%- for configname in cfg_minion %}
 {%- if configname not in reserved_keys and configname not in default_keys %}
-  {%- if cfg_minion[configname] is iterable and cfg_minion[configname] is not string %}
+  {%- if cfg_minion[configname] is iterable and cfg_minion[configname] is not mapping and cfg_minion[configname] is not string %}
 {{ configname }}:
     {%- for item in cfg_minion[configname] %}
   - {{ item }}


### PR DESCRIPTION
Extra config stored as a dict is iterable, but needs a different yaml structure from a list.

Since the existing code only handles the first level of the configuration and does not traverse recursively, I don't think there's much value in adding special handling for mappings.
So just treat those the same as strings (which results in a JSON string being put in the config).