### PR TITLE
Stop noise from unless parameter

### DIFF
--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -51,7 +51,7 @@
     - require:
       - file: {{ basedir }}
     {%- if not update %}
-    - unless: test -e {{ gitdir }} >/dev/null 2>&1
+    - onlyif: test -e {{ gitdir }} >/dev/null 2>&1 | true
     {%- endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
This PR stops Salt noise when `gitdir` is missing. Verified on Centos7
```
[ERROR   ] Command 'test -e /srv/formulas/epel-formula >/dev/null 2>&1' failed with return code: 1
[ERROR   ] retcode: 1
[ERROR   ] Command 'test -e /srv/formulas/openssh-formula >/dev/null 2>&1' failed with return code: 1
[ERROR   ] retcode: 1
[ERROR   ] Command 'test -e /srv/formulas/packages-formula >/dev/null 2>&1' failed with return code: 1
[ERROR   ] retcode: 1

```