### PR TITLE
Move some defaults from pillar.example to defaults

### DIFF
--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -56,3 +56,10 @@ salt:
 
 salt_formulas:
   checkout_orig_branch: False
+  git_opts:
+    default:
+      baseurl: https://github.com/saltstack-formulas
+      basedir: /srv/formulas
+      update: False
+      options:
+        rev: master

--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -63,3 +63,4 @@ salt_formulas:
       update: False
       options:
         rev: master
+        output_loglevel: 'quiet'


### PR DESCRIPTION
This PR moves some (good) defaults from pillar.example into default.yaml.  That's what defaults.yaml is for so makes sense to me.

This PR also replaces #389 setting `output_loglevel: quiet` to shutoff unless/onlyif noise.