### PR TITLE
Add missing GitPython-package for Arch

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -117,6 +117,7 @@ that differ from whats in defaults.yaml
       'salt_cloud':  'salt',
       'salt_api': 'salt',
       'salt_ssh':  'salt',
+      'python_git': 'python2-gitpython',
       'pygit2': 'python2-pygit2',
       'libgit2': 'libgit2',
       'pyinotify': 'python2-pyinotify',


### PR DESCRIPTION
Without specifying this the `salt.gitfs.gitpython` state is unusable on Arch, because it tries to install a `python-git` package which doesn't exist.