### PR TITLE
Fix `repo.saltstack.com` URLs for pinned minor release (#364)

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -41,6 +41,12 @@ that differ from whats in defaults.yaml
 ##}
 {% set osrelease = salt['grains.get']('osrelease') %}
 {% set salt_release = salt['pillar.get']('salt:release', 'latest') %}
+
+{# All minor releases appear in an `archive` sub-directory #}
+{% if salt_release.split('.')|length >= 3 %}
+{% set salt_release = 'archive/' ~ salt_release %}
+{% endif %}
+
 {% set os_family_map = salt['grains.filter_by']({
     'Debian':  {
       'pkgrepo': 'deb http://repo.saltstack.com/apt/' +


### PR DESCRIPTION
* All minor releases appear in an `archive` sub-directory.
* Resolves main bug in GitHub issue #364.
* Simplification of original GitHub PR #365 by @ralucasg.

---

When looking into issue #364, I ended up embarking on an [epic discussion](https://github.com/saltstack-formulas/salt-formula/issues/364#issuecomment-457110950) uncovering further issues with the current implementation of linking to https://repo.saltstack.com.  The quote below has been trimmed from that discourse, so is a little disjointed, such as the numbering in the tables.  I'm including it because it shows all of the URLs that require `archive/` before the minor release version number:

> #### Debian
> 
> #|Pin|Py|Key|Repo|Direct
> -----|-----|-----|-----|-----|-----
> 7|Minor|2|https://repo.saltstack.com/apt/debian/9/amd64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/apt/debian/9/amd64/archive/2018.3.3 stretch main| 
> 8|Minor|3|https://repo.saltstack.com/py3/debian/9/amd64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/debian/9/amd64/archive/2018.3.3 stretch main| 
> 9|Minor|2|https://repo.saltstack.com/apt/debian/8/amd64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/apt/debian/8/amd64/archive/2018.3.3 jessie main| 
> 
> #### Red Hat / CentOS
> 
> #|Pin|Py|Key|Repo|Direct
> -----|-----|-----|-----|-----|-----
> 16|Minor|2|https://repo.saltstack.com/yum/redhat/7/x86\_64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|https://repo.saltstack.com/yum/redhat/$releasever/$basearch/archive/2018.3.3| 
> 17|Minor|3|https://repo.saltstack.com/py3/redhat/7/x86\_64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|https://repo.saltstack.com/py3/redhat/$releasever/$basearch/archive/2018.3.3| 
> 18|Minor|2|https://repo.saltstack.com/yum/redhat/6/x86\_64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|https://repo.saltstack.com/yum/redhat/$releasever/$basearch/archive/2018.3.3| 
> 
> #### Ubuntu
> 
> #|Pin|Py|Key|Repo|Direct
> -----|-----|-----|-----|-----|-----
> 29|Minor|2|https://repo.saltstack.com/apt/ubuntu/18.04/amd64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/apt/ubuntu/18.04/amd64/archive/2018.3.3 bionic main| 
> 30|Minor|2|https://repo.saltstack.com/apt/ubuntu/16.04/amd64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/apt/ubuntu/16.04/amd64/archive/2018.3.3 xenial main| 
> 31|Minor|3|https://repo.saltstack.com/py3/ubuntu/18.04/amd64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/ubuntu/18.04/amd64/archive/2018.3.3 bionic main| 
> 32|Minor|3|https://repo.saltstack.com/py3/ubuntu/16.04/amd64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/ubuntu/16.04/amd64/archive/2018.3.3 xenial main| 
> 33|Minor|2|https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2018.3.3 trusty main| 
> 
> #### Amazon Linux
> 
> #|Pin|Py|Key|Repo|Direct
> -----|-----|-----|-----|-----|-----
> 53|Minor|2|https://repo.saltstack.com/yum/amazon/2/x86\_64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|https://repo.saltstack.com/yum/amazon/2/$basearch/archive/2018.3.3| 
> 54|Minor|2|https://repo.saltstack.com/yum/amazon/latest/x86\_64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|https://repo.saltstack.com/yum/amazon/latest/$basearch/archive/2018.3.3| 
> 
> #### Raspbian
> 
> #|Pin|Py|Key|Repo|Direct
> -----|-----|-----|-----|-----|-----
> 61|Minor|2|https://repo.saltstack.com/apt/debian/9/armhf/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/apt/debian/9/armhf/archive/2018.3.3 stretch main| 
> 62|Minor|3|https://repo.saltstack.com/py3/debian/9/armhf/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/debian/9/armhf/archive/2018.3.3 stretch main| 
> 63|Minor|2|https://repo.saltstack.com/apt/debian/8/armhf/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/apt/debian/8/armhf/archive/2018.3.3 jessie main| 

---

One point about the implementation:

```jinja
{% if salt_release.split('.')|length >= 3 %}
```

* Virtually every minor release is in the 3-number format (e.g. `2018.3.3`) but there are some with four numbers, hence the use of `>= 3`:
    * E.g. https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.8.2/.

---

Update: I had to restart the CI job for `salt-centos-7` and it got through the second time -- might be something to keep an eye on.

---

Update: Force push was because I realised that I could attribute authorship by using the GitHub no-reply e-mail address.