### PR TITLE
Fix `salt:lookup` regression

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -6,9 +6,6 @@
 {% import_yaml "salt/osfamilymap.yaml" as osfamilymap %}
 {% import_yaml "salt/osmap.yaml" as osmap %}
 
-{% set lookup = salt['pillar.get']('salt:lookup', default={}, merge=True) %}
-{% do defaults.salt.update(lookup) %}
-
 {# merge the osfamilymap #}
 {% set osfamily = salt['grains.filter_by'](osfamilymap, grain='os_family') or{} %}
 {% do salt['defaults.merge'](defaults['salt'], osfamily) %}
@@ -16,6 +13,10 @@
 {# merge the osmap #}
 {% set osmap = salt['grains.filter_by'](osmap, grain='os') or{} %}
 {% do salt['defaults.merge'](defaults['salt'], osmap) %}
+
+{# merge the lookup #}
+{% set lookup = salt['pillar.get']('salt:lookup', default={}, merge=True) %}
+{% do salt['defaults.merge'](defaults['salt'], lookup) %}
 
 {## Merge in salt pillar ##}
 {% set salt_settings = salt['pillar.get']('salt', default=defaults['salt'], merge=True) %}


### PR DESCRIPTION
Full discussion at https://github.com/saltstack-formulas/apache-formula/pull/252.

---

With a `lookup` of:

```yaml
salt:
  # to overwrite map.jinja salt packages
  lookup:
    pyinotify: 'pyinotify'
```

Diff of before vs. after #395:

```diff
--- 44b06d7
+++ 1d9643b
@@ -91,6 +91,12 @@
   },
   "config_path": "/etc/salt",
   "gitfs": {
+    "dulwich": {
+      "install_from_source": true
+    },
+    "gitpython": {
+      "install_from_source": false
+    },
     "pygit2": {
       "git": {
         "install_from_package": null,
@@ -98,7 +104,10 @@
       },
       "install_from_source": false,
       "libgit2": {
-        "install_from_source": false
+        "build_parent_dir": "/usr/src/",
+        "download_hash": "683d1164e361e2a0a8d52652840e2340",
+        "install_from_source": false,
+        "version": "0.23.0"
       },
       "version": "0.22.1"
     }
@@ -147,7 +156,7 @@
   "minion_service": "salt-minion",
   "pkgrepo": "deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2018.3.3 trusty main",
   "pygit2": "python-pygit2",
-  "pyinotify": "pyinotify",
+  "pyinotify": "python-pyinotify",
   "python_dulwich": "python-dulwich",
   "python_git": "python-git",
   "release": "2018.3.3",
```

* Has the improvements mentioned at https://github.com/saltstack-formulas/salt-formula/pull/395#issuecomment-457820419.
* However, regression present in the `lookup` of `pyinotify`.

As for the diff of before vs. this PR:

```diff
--- 44b06d7
+++ 68cbd17
@@ -91,6 +91,12 @@
   },
   "config_path": "/etc/salt",
   "gitfs": {
+    "dulwich": {
+      "install_from_source": true
+    },
+    "gitpython": {
+      "install_from_source": false
+    },
     "pygit2": {
       "git": {
         "install_from_package": null,
@@ -98,7 +104,10 @@
       },
       "install_from_source": false,
       "libgit2": {
-        "install_from_source": false
+        "build_parent_dir": "/usr/src/",
+        "download_hash": "683d1164e361e2a0a8d52652840e2340",
+        "install_from_source": false,
+        "version": "0.23.0"
       },
       "version": "0.22.1"
     }
```

* Maintains the improvements mentioned at https://github.com/saltstack-formulas/salt-formula/pull/395#issuecomment-457820419.
* Regression resolved for the `lookup` of `pyinotify`.