### PR TITLE
Fix `repo.saltstack.com` URLs for Python 3 packages (#364)

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -10,6 +10,10 @@ salt:
   # This state will remove "/etc/salt/master" when you set this to true.
   master_remove_config: True
 
+  # Set this to 'py3' to install the Python 3 packages.
+  # If this is not set, the Python 2 packages will be installed by default.
+  py_ver: 'py3'
+
   # Set this to False to not have the formula install packages (in the case you
   # install Salt via git/pip/etc.)
   install_packages: True

--- a/salt/osfamilymap.yaml
+++ b/salt/osfamilymap.yaml
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 
+{% import_yaml "salt/ospyvermap.yaml" as ospyvermap %}
+{% set ospyver = salt['grains.filter_by'](ospyvermap, grain='os_family') or {} %}
+{% set py_ver_dir = salt['pillar.filter_by'](ospyver, pillar='salt:py_ver', default='py2') %}
+
 {% set osrelease = salt['grains.get']('osrelease') %}
 {% set salt_release = salt['pillar.get']('salt:release', 'latest') %}
 {% if salt_release.split('.')|length >= 3 %}
@@ -11,8 +15,8 @@
 {% set oscodename = salt['grains.get']('oscodename') %}
 
 Debian:
-  pkgrepo: 'deb http://repo.saltstack.com/apt/{{ os_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
-  key_url: 'https://repo.saltstack.com/apt/{{ os_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
+  pkgrepo: 'deb http://repo.saltstack.com/{{ py_ver_dir }}/{{ os_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
+  key_url: 'https://repo.saltstack.com/{{ py_ver_dir }}/{{ os_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
   libgit2: libgit2-22
   pyinotify: python-pyinotify
   gitfs:
@@ -26,8 +30,8 @@ Debian:
         install_from_source: False
 
 RedHat:
-  pkgrepo: 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/{{ salt_release }}'
-  key_url: 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
+  pkgrepo: 'https://repo.saltstack.com/{{ py_ver_dir }}/redhat/$releasever/$basearch/{{ salt_release }}'
+  key_url: 'https://repo.saltstack.com/{{ py_ver_dir }}/redhat/$releasever/$basearch/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
   pygit2: python-pygit2
   python_git: GitPython
   gitfs:

--- a/salt/osmap.yaml
+++ b/salt/osmap.yaml
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 
+{% import_yaml "salt/ospyvermap.yaml" as ospyvermap %}
+{% set ospyver = salt['grains.filter_by'](ospyvermap, grain='os_family') or {} %}
+{% set py_ver_dir = salt['pillar.filter_by'](ospyver, pillar='salt:py_ver', default='py2') %}
+
 {% set osrelease = salt['grains.get']('osrelease') %}
 {% set salt_release = salt['pillar.get']('salt:release', 'latest') %}
 {% if salt_release.split('.')|length >= 3 %}
@@ -14,8 +18,8 @@ Fedora:
   pygit2: python2-pygit2
 
 Ubuntu:
-  pkgrepo: 'deb http://repo.saltstack.com/apt/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
-  key_url: 'https://repo.saltstack.com/apt/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
+  pkgrepo: 'deb http://repo.saltstack.com/{{ py_ver_dir }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
+  key_url: 'https://repo.saltstack.com/{{ py_ver_dir }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
   pygit2: python-pygit2
   gitfs:
     pygit2:
@@ -25,8 +29,8 @@ Ubuntu:
         install_from_package: Null
 
 Raspbian:
-  pkgrepo: 'deb http://repo.saltstack.com/apt/{{ os_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }} {{ oscodename }} main'
-  key_url: 'https://repo.saltstack.com/apt/{{ os_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
+  pkgrepo: 'deb http://repo.saltstack.com/{{ py_ver_dir }}/{{ os_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }} {{ oscodename }} main'
+  key_url: 'https://repo.saltstack.com/{{ py_ver_dir }}/{{ os_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
 
 SmartOS:
   salt_master: salt
@@ -45,6 +49,3 @@ SmartOS:
   config_path: /opt/local/etc/salt
   master:
     gitfs_provider: dulwich
-
-
-

--- a/salt/ospyvermap.yaml
+++ b/salt/ospyvermap.yaml
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+
+Debian:
+  py2: 'apt'
+  py3: 'py3'
+
+RedHat:
+  py2: 'yum'
+  py3: 'py3'
+
+Suse: {}
+
+Gentoo: {}
+
+Arch: {}
+
+Alpine: {}
+
+FreeBSD: {}
+
+OpenBSD: {}
+
+Windows:
+  py2: 'Py2'
+  py3: 'Py3'
+
+MacOS:
+  py2: 'py2'
+  py3: 'py3'


### PR DESCRIPTION
From findings in https://github.com/saltstack-formulas/salt-formula/issues/364#issuecomment-457110950:

> ### Further issues (e.g. lack of `PY3` support)
> 
> Having collated the URLs, I've identified further issues.  For example, the formula does not currently support `PY3` installations.  It would be advantageous to resolve these issues concurrently.

This PR fixes the `PY3` links for the following URLs:

> #### Debian
> 
> #|Pin|Py|Key|Repo|Direct
> -----|-----|-----|-----|-----|-----
> 2|Latest|3|https://repo.saltstack.com/py3/debian/9/amd64/latest/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/debian/9/amd64/latest stretch main| 
> 5|Major|3|https://repo.saltstack.com/py3/debian/9/amd64/2018.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/debian/9/amd64/2018.3 stretch main| 
> 8|Minor|3|https://repo.saltstack.com/py3/debian/9/amd64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/debian/9/amd64/archive/2018.3.3 stretch main| 
> 
> #### Red Hat / CentOS
> 
> #|Pin|Py|Key|Repo|Direct
> -----|-----|-----|-----|-----|-----
> 17|Minor|3|https://repo.saltstack.com/py3/redhat/7/x86\_64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|https://repo.saltstack.com/py3/redhat/$releasever/$basearch/archive/2018.3.3| 
> 
> #### Ubuntu
> 
> #|Pin|Py|Key|Repo|Direct
> -----|-----|-----|-----|-----|-----
> 21|Latest|3|https://repo.saltstack.com/py3/ubuntu/18.04/amd64/latest/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/ubuntu/18.04/amd64/latest bionic main| 
> 22|Latest|3|https://repo.saltstack.com/py3/ubuntu/16.04/amd64/latest/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/ubuntu/16.04/amd64/latest xenial main| 
> 26|Major|3|https://repo.saltstack.com/py3/ubuntu/18.04/amd64/2018.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/ubuntu/18.04/amd64/2018.3 bionic main| 
> 27|Major|3|https://repo.saltstack.com/py3/ubuntu/16.04/amd64/2018.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/ubuntu/16.04/amd64/2018.3 xenial main| 
> 31|Minor|3|https://repo.saltstack.com/py3/ubuntu/18.04/amd64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/ubuntu/18.04/amd64/archive/2018.3.3 bionic main| 
> 32|Minor|3|https://repo.saltstack.com/py3/ubuntu/16.04/amd64/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/ubuntu/16.04/amd64/archive/2018.3.3 xenial main| 
> 
> #### Raspbian
> 
> #|Pin|Py|Key|Repo|Direct
> -----|-----|-----|-----|-----|-----
> 56|Latest|3|https://repo.saltstack.com/py3/debian/9/armhf/latest/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/debian/9/armhf/latest stretch main| 
> 59|Major|3|https://repo.saltstack.com/py3/debian/9/armhf/2018.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/debian/9/armhf/2018.3 stretch main| 
> 62|Minor|3|https://repo.saltstack.com/py3/debian/9/armhf/archive/2018.3.3/SALTSTACK-GPG-KEY.pub|http://repo.saltstack.com/py3/debian/9/armhf/archive/2018.3.3 stretch main| 