### PR TITLE
Make pkgrepo work for Debian derivatives without their own repos

### DIFF
--- a/salt/osfamilymap.yaml
+++ b/salt/osfamilymap.yaml
@@ -10,13 +10,13 @@
 {% if salt_release.split('.')|length >= 3 %}
 {% set salt_release = 'archive/' ~ salt_release %}
 {% endif %}
-{% set os_lower =  salt['grains.get']('os')|lower %}
+{% set osfamily_lower =  salt['grains.get']('os_family')|lower %}
 {% set osmajorrelease = salt['grains.get']('osmajorrelease', osrelease)|string %}
 {% set oscodename = salt['grains.get']('oscodename') %}
 
 Debian:
-  pkgrepo: 'deb http://repo.saltstack.com/{{ py_ver_dir }}/{{ os_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
-  key_url: 'https://repo.saltstack.com/{{ py_ver_dir }}/{{ os_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
+  pkgrepo: 'deb http://repo.saltstack.com/{{ py_ver_dir }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
+  key_url: 'https://repo.saltstack.com/{{ py_ver_dir }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
   libgit2: libgit2-22
   pyinotify: python-pyinotify
   gitfs:


### PR DESCRIPTION
For osfamilymap to be useful for Debian derivatives that don't have their own apt repos,
osfamilymap should make use of the `os_family` grain rather than the `os` grain.

e.g. TurnKey Linux has the following os grains:
```
    os:      
        TurnKey                       
    os_family:      
        Debian
    osarch:
        amd64
    oscodename:
        stretch  
    osfinger:
        TurnKey-9
    osfullname:  
        TurnKey
    osmajorrelease:
        9      
    osrelease:
        9.7 
    osrelease_info:
        - 9      
        - 7         
```
cf. vanilla Debian
```
    os:         
        Debian  
    os_family:      
        Debian
    osarch:
        amd64
    oscodename:
        stretch  
    osfinger:
        Debian-9
    osfullname:   
        Debian
    osmajorrelease:
        9      
    osrelease:
        9.6 
    osrelease_info:
        - 9      
        - 6
```