### PR TITLE
Reformat `formulas.sls` Jinja to make it easier to work with

### DIFF
--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -1,68 +1,70 @@
-{% set processed_gitdirs = {} %}
-{% set processed_gitdir_envs = [] %}
-{% set processed_basedirs = [] %}
+{%- set processed_gitdirs = {} %}
+{%- set processed_gitdir_envs = [] %}
+{%- set processed_basedirs = [] %}
 
-{% from "salt/map.jinja" import formulas_settings with context %}
-{% from "salt/formulas.jinja" import formulas_git_opt with context %}
-{% from "salt/formulas.jinja" import formulas_opts_for_git_latest with context %}
+{%- from "salt/map.jinja" import formulas_settings with context %}
+{%- from "salt/formulas.jinja" import formulas_git_opt with context %}
+{%- from "salt/formulas.jinja" import formulas_opts_for_git_latest with context %}
 
 # Loop over all formulas listed in pillar data
-{% for env, entries in salt['pillar.get']('salt_formulas:list', {}).items() %}
-{% for entry in entries %}
+{%- for env, entries in salt['pillar.get']('salt_formulas:list', {}).items() %}
+{%-   for entry in entries %}
 
-{% set basedir = formulas_git_opt(env, 'basedir')|load_yaml %}
-{% set gitdir = '{0}/{1}'.format(basedir, entry) %}
-{% set update = formulas_git_opt(env, 'update')|load_yaml %}
+{%-     set basedir = formulas_git_opt(env, 'basedir')|load_yaml %}
+{%-     set gitdir = '{0}/{1}'.format(basedir, entry) %}
+{%-     set update = formulas_git_opt(env, 'update')|load_yaml %}
 
-{% if formulas_settings.checkout_orig_branch %}
-{% if not salt['file.directory_exists']('{0}/{1}'.format(gitdir, '.git')) %}
-{% set gitdir_branch = '' %}
-{% else %}
-{% set gitdir_branch = salt['git.current_branch'](gitdir) %}
-{% endif %}
-{% do processed_gitdirs.update({gitdir:gitdir_branch}) %}
-{% endif %}
+{%-     if formulas_settings.checkout_orig_branch %}
+{%-       if not salt['file.directory_exists']('{0}/{1}'.format(gitdir, '.git')) %}
+{%-         set gitdir_branch = '' %}
+{%-       else %}
+{%-         set gitdir_branch = salt['git.current_branch'](gitdir) %}
+{%-       endif %}
+{%-       do processed_gitdirs.update({gitdir:gitdir_branch}) %}
+{%-     endif %}
 
 # Setup the directory hosting the Git repository
-{% if basedir not in processed_basedirs %}
-{% do processed_basedirs.append(basedir) %}
+{%-     if basedir not in processed_basedirs %}
+{%-       do processed_basedirs.append(basedir) %}
 {{ basedir }}:
   file.directory:
-    {%- for key, value in salt['pillar.get']('salt_formulas:basedir_opts',
-                                             {'makedirs': True}).items() %}
+    {%-   for key, value in salt['pillar.get'](
+            'salt_formulas:basedir_opts',
+            {'makedirs': True}
+          ).items() %}
     - {{ key }}: {{ value }}
-    {%- endfor %}
-{% endif %}
+    {%-   endfor %}
+{%-     endif %}
 
 # Setup the formula Git repository
-{% set gitdir_env = '{0}_{1}'.format(gitdir, env) %}
-{% if gitdir_env not in processed_gitdir_envs %}
-{% do processed_gitdir_envs.append(gitdir_env) %}
-{% set options = formulas_opts_for_git_latest(env)|load_yaml %}
-{% set baseurl = formulas_git_opt(env, 'baseurl')|load_yaml %}
+{%-     set gitdir_env = '{0}_{1}'.format(gitdir, env) %}
+{%-     if gitdir_env not in processed_gitdir_envs %}
+{%-       do processed_gitdir_envs.append(gitdir_env) %}
+{%-       set options = formulas_opts_for_git_latest(env)|load_yaml %}
+{%-       set baseurl = formulas_git_opt(env, 'baseurl')|load_yaml %}
 
 {{ gitdir_env }}:
   git.latest:
     - name: {{ baseurl }}/{{ entry }}.git
     - target: {{ gitdir }}
-    {%- for key, value in options.items() %}
+    {%-   for key, value in options.items() %}
     - {{ key }}: {{ value }}
-    {%- endfor %}
+    {%-   endfor %}
     - require:
       - file: {{ basedir }}
     {%- if not update %}
     - onlyif: rm -fr {{ gitdir }} >/dev/null 2>&1 | true
     {%- endif %}
-{% endif %}
-{% endfor %}
-{% endfor %}
+{%-     endif %}
+{%-   endfor %}
+{%- endfor %}
 
-{% if formulas_settings.checkout_orig_branch %}
+{%- if formulas_settings.checkout_orig_branch %}
 # For each directory processed, explicitly checkout the original branch before
 # the `git.latest` state ran
-{% for gitdir, original_branch in processed_gitdirs.items() %}
-{% if original_branch %}
-{% set gitdir_user = salt['file.get_user'](gitdir) %}
+{%-   for gitdir, original_branch in processed_gitdirs.items() %}
+{%-     if original_branch %}
+{%-       set gitdir_user = salt['file.get_user'](gitdir) %}
 checkout_original_branch_for_{{ gitdir }}:
   module.run:
     - name: git.checkout
@@ -71,6 +73,6 @@ checkout_original_branch_for_{{ gitdir }}:
     - rev: {{ original_branch }}
     - user: {{ gitdir_user }}
     - unless: test "$(cd {{ gitdir }}; git rev-parse --abbrev-ref HEAD)" = "{{ original_branch }}"
-{% endif %}
-{% endfor %}
-{% endif %}
+{%-     endif %}
+{%-   endfor %}
+{%- endif %}

--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -28,10 +28,8 @@
 {%-       do processed_basedirs.append(basedir) %}
 {{ basedir }}:
   file.directory:
-    {%-   for key, value in salt['pillar.get'](
-            'salt_formulas:basedir_opts',
-            {'makedirs': True}
-          ).items() %}
+    {%-   for key, value in salt['pillar.get']('salt_formulas:basedir_opts',
+                                               {'makedirs': True}).items() %}
     - {{ key }}: {{ value }}
     {%-   endfor %}
 {%-     endif %}
@@ -52,9 +50,9 @@
     {%-   endfor %}
     - require:
       - file: {{ basedir }}
-    {%- if not update %}
+    {%-   if not update %}
     - onlyif: rm -fr {{ gitdir }} >/dev/null 2>&1 | true
-    {%- endif %}
+    {%-   endif %}
 {%-     endif %}
 {%-   endfor %}
 {%- endfor %}


### PR DESCRIPTION
NOTE: This refactor does nothing more than modify whitespace.  No change is made to the functionality at all.

---

While looking at #403, the logic is incredibly difficult to follow.  This PR adapts the Jinja to make each much easier to comprehend and work with.

---

It's easier to appreciate the changes by viewing the [whole file](https://github.com/saltstack-formulas/salt-formula/blob/f76364c1b7afffc435656a76b8c3ed49b364579d/salt/formulas.sls) rather than the diff.

Update: After the second commit, this is the [whole file](https://github.com/saltstack-formulas/salt-formula/blob/922135df31875e928e75dc5ad18dcaba7cb3ae0f/salt/formulas.sls).