### PR TITLE
ci(kitchen+travis): use `py2` instead of `py3` for `centos-7`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   matrix:
     - INSTANCE: v2019-2-py3-debian-9
     - INSTANCE: v2019-2-py3-ubuntu-1804
-    - INSTANCE: v2019-2-py3-centos-7
+    - INSTANCE: v2019-2-py2-centos-7
     - INSTANCE: v2019-2-py2-fedora-29
 
     - INSTANCE: v2018-3-py2-debian-8

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -83,14 +83,7 @@ suites:
     includes:
       - debian-9
       - ubuntu-18.04
-      - centos-7
     provisioner:
-      # If we don't force bootstrapping with python3, centos bootstraps using python2
-      # and then, when switching the repo to python3 and tries to install
-      # the packages, complains with
-      # Downloading packages:
-      #   https://repo.saltstack.com/py3/re.........rpm: [Errno -1] Package does not
-      # match intended download. Suggestion: run yum --enablerepo=saltstack clean metadata
       salt_bootstrap_options: -X -x python3 -d git %s
       salt_version: '2019.2'
       pillars:
@@ -107,6 +100,7 @@ suites:
   # Fedora ships updated py2 versions in their own repos
   - name: v2019-2-py2
     includes:
+      - centos-7
       - fedora-29
     provisioner:
       salt_version: '2019.2'


### PR DESCRIPTION
As discussed with @javierbertoli on Slack, there's just too much trouble getting Python 3 working on `centos-7` for testing purposes.  Dropping back to `py2` for dependable testing.