### PR TITLE
feat(per-formula-opts): configure git.latest state per formula

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -424,10 +424,18 @@ salt_formulas:
     base:
       - salt-formula
       - postfix-formula
+      - nginx-formula:  # We can also override some options per formula
+          rev: 'v1.1.0'  # Pin a version
+      - openssh-formula:
+          rev: '3e01ad8'  # or pin a commit id
     dev:
       - salt-formula
       - postfix-formula
       - openssh-formula
+      - nginx-formula:
+          # You can also pull from another location
+          name: 'https://github.com/another-fork-location/salt-formula.git'
+          rev: 'feat/feature'
     # Likewise for the alternative method (single directory, multiple branches)
     production:
       - salt-formula

--- a/salt/formulas.jinja
+++ b/salt/formulas.jinja
@@ -25,7 +25,8 @@
 
 {%- macro formulas_roots(env) -%}
 {%- set value = [] -%}
-{%- for dir in formulas.get(env, []) -%}
+{%- for formula in formulas.get(env, []) -%}
+{%- set dir = formula | first if formula is mapping else formula %}
 {%- set basedir = formulas_git_opt(env, 'basedir')|load_yaml -%}
 {%- do value.append('{0}/{1}'.format(basedir, dir)) -%}
 {%- endfor -%}

--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -13,9 +13,11 @@
 # Loop over all formulas listed in pillar data
 {%- for env, entries in salt['pillar.get']('salt_formulas:list', {}).items() %}
 {%-   for entry in entries %}
+{%-     set f_name = entry | first if entry is mapping else entry %}
+{%-     set f_opts = entry[f_name] if entry is mapping else {}    %}
 
 {%-     set basedir = formulas_git_opt(env, 'basedir')|load_yaml %}
-{%-     set gitdir = '{0}/{1}'.format(basedir, entry) %}
+{%-     set gitdir = '{0}/{1}'.format(basedir, f_name) %}
 {%-     set update = formulas_git_opt(env, 'update')|load_yaml %}
 
 {%-     if formulas_settings.checkout_orig_branch %}
@@ -45,11 +47,12 @@
 {%-     if gitdir_env not in processed_gitdir_envs %}
 {%-       do processed_gitdir_envs.append(gitdir_env) %}
 {%-       set options = formulas_opts_for_git_latest(env)|load_yaml %}
+{%-       do options.update(f_opts) %}
 {%-       set baseurl = formulas_git_opt(env, 'baseurl')|load_yaml %}
 
 {{ gitdir_env }}:
   git.latest:
-    - name: {{ baseurl }}/{{ entry }}.git
+    - name: {{ baseurl }}/{{ f_name }}.git
     - target: {{ gitdir }}
     {%-   for key, value in options.items() %}
     - {{ key }}: {{ value }}


### PR DESCRIPTION
Proposition of a little enhancement on salt_formulas which permits to customize git.latest options on per-formula basis.
Relevant portion of pillar.example is:
```yaml
salt_formulas:
(...)
 list:
    base:
      - salt-formula
      - postfix-formula
      - nginx-formula: # We can also override some options per formula
          rev: 'v1.1.0'  # Pin a version
      - openssh-formula:
          rev: '3e01ad8' # or pin a commit id
    dev:
      - salt-formula
      - postfix-formula
      - openssh-formula
      - nginx-formula:
          # You can also pull from another location
          name: 'https://github.com/another-fork-location/salt-formula.git'
          rev:  'feat/feature'
```