### PR TITLE
feat(formula): add metastate per community convention

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -45,6 +45,13 @@ Available states
 .. contents::
    :local:
 
+``salt``
+^^^^^^^^
+
+*Meta-state (This is a state that includes other states)*.
+
+This calls all runable states based on configured pillar data.
+
 ``salt.minion``
 ^^^^^^^^^^^^^^^
 

--- a/pillar.example
+++ b/pillar.example
@@ -80,6 +80,7 @@ salt:
   # salt master config
   master_config_use_TOFS: true
   master:
+    standalone: false
     fileserver_backend:
       - git
       - s3fs
@@ -162,6 +163,9 @@ salt:
   # salt minion config:
   minion_config_use_TOFS: true
   minion:
+
+    # standalone setup
+    master_type: false   # see init.sls & standalone.sls
 
     # single master setup
     master: salt
@@ -267,6 +271,13 @@ salt:
       functions_blacklist:
         - test.ping
         - saltutil.find_job
+
+  # init.sls skips salt.api and salt.syndic states
+  # unless those dicts are populated with something
+  api:
+    somekey: somevalue
+  syndic:
+    somekey: somevalue
 
   # salt cloud config
   cloud:

--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -30,11 +30,16 @@ salt:
   salt_api: salt-api
   salt_ssh: salt-ssh
 
+  pkgrepo: ''          # see osfamilymap
+  ssh_roster: {}       # see pillar data
+
   python_git: python-git
   python_dulwich: python-dulwich
 
   master:
     gitfs_provider: gitpython
+  minion:
+    master_type: true  # see init.sls & standalone.sls
 
   gitfs:
     dulwich:
@@ -62,6 +67,7 @@ salt:
       maps: salt://salt/files/cloud.maps.d
 
 salt_formulas:
+  list: {}     # via pillar data
   checkout_orig_branch: false
   git_opts:
     default:

--- a/salt/init.sls
+++ b/salt/init.sls
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+include:
+  - salt.pkgrepo
+      {%- if salt.config.get('salt_formulas:list') %}
+  - salt.formulas
+      {%- endif %}
+      {%- if salt.config.get('salt:master')|length > 1 %}
+  - salt.master
+      {%- endif %}
+      {%- if salt.config.get('salt:cloud')|length > 1 %}
+  - salt.cloud
+      {%- endif %}
+      {%- if salt.config.get('salt:ssh_roster') %}
+  - salt.ssh
+      {%- endif %}
+      {%- if salt.config.get('salt:minion')|length > 1 %}
+          {%- if salt.config.get('salt:minion:master_type') %}
+  - salt.minion
+          {%- else %}
+  - salt.standalone
+          {%- endif %}
+      {%- endif %}
+      {%- if salt.config.get('salt:api') %}
+  - salt.api
+      {%- endif %}
+      {%- if salt.config.get('salt:syndic') %}
+  - salt.syndic
+      {%- endif %}

--- a/salt/pkgrepo/init.sls
+++ b/salt/pkgrepo/init.sls
@@ -1,2 +1,10 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "salt/map.jinja" import salt_settings with context %}
+
+  {%- if salt_settings.pkgrepo %}
+
 include:
   - .{{ grains['os_family']|lower }}
+
+  {%- endif %}

--- a/salt/standalone.sls
+++ b/salt/standalone.sls
@@ -1,14 +1,14 @@
 {%- set tplroot = tpldir.split('/')[0] %}
 {% from "salt/map.jinja" import salt_settings with context %}
 
-salt-minion:
-{% if salt_settings.install_packages %}
+salt-minion-standalone:
+  {% if salt_settings.install_packages %}
   pkg.installed:
     - name: {{ salt_settings.salt_minion }}
-  {%- if salt_settings.version is defined %}
+     {%- if salt_settings.version is defined %}
     - version: {{ salt_settings.version }}
-  {%- endif %}
-{% endif %}
+     {%- endif %}
+  {% endif %}
   file.recurse:
     - name: {{ salt_settings.config_path }}/minion.d
     - template: jinja
@@ -17,19 +17,19 @@ salt-minion:
     - exclude_pat: _*
     - context:
         standalone: True
-{%- if salt_settings.minion.master_type is defined and salt_settings.minion.master_type == 'disable' %}
+  {%- if not salt_settings.minion.master_type %}
   service.running:
     - enable: True
-{%- else %}
+  {%- else %}
   service.dead:
     - enable: False
-{%- endif %}
+  {%- endif %}
     - name: {{ salt_settings.minion_service }}
     - require:
-{% if salt_settings.install_packages %}
-      - pkg: salt-minion
-{% endif %}
-      - file: salt-minion
+  {% if salt_settings.install_packages %}
+      - pkg: salt-minion-standalone
+  {% endif %}
+      - file: salt-minion-standalone
 
 # clean up old _defaults.conf file if they have it around
 remove-old-standalone-conf-file:


### PR DESCRIPTION
Resolves #410 and helps #352.  Using this metastate is optional.

In particular, this metastate avoids having developers reinvent the wheel, i.e.  https://github.com/opensds/opensds-installer/blob/c3e8b45a75b3ce1589f0d2ae680e8302ec9c4dd2/salt/srv/salt/install/salt.sls#L1