### PR TITLE
refactor(linux): align to template-formula & fixes

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -107,13 +107,12 @@ For EL distributions, pygit is installed from packages from `EPEL <https://githu
 ``salt.pkgrepo``
 ^^^^^^^^^^^^^^^^
 
-Enable the official saltstack package repository in order to always
-benefit from the latest version. This state currently only works on Debian, Ubuntu, RHEL 6/7 and aims to implement the `installation recommendations of the official documentation <http://docs.saltstack.com/en/latest/topics/installation/index.html#platform-specific-installation-instructions>`_.
+It is recommended to use SaltStack repository for Debian, RedHat, and SuSE, to benefit from the latest stable salt release. Refer to official documentation at <http://docs.saltstack.com/en/latest/topics/installation/index.html#platform-specific-installation-instructions>`_.
 
-``salt.pkgrepo.absent``
+``salt.pkgrepo.clean``
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Undo the effects of ``salt.pkgrepo``.
+Undo the effects of ``salt.pkgrepo`` on Debian, RedHat, and SuSE.
 
 ``salt.formulas``
 ^^^^^^^^^^^^^^^^^

--- a/salt/pkgrepo/debian/absent.sls
+++ b/salt/pkgrepo/debian/absent.sls
@@ -1,11 +1,1 @@
-{% from "salt/map.jinja" import salt_settings with context %}
-
-drop-saltstack-pkgrepo:
-  pkgrepo.absent:
-    - name: {{ salt_settings.pkgrepo }}
-  file.absent:
-    - name: /etc/apt/sources.list.d/saltstack.list
-
-drop-saltstack-apt-key:
-  file.absent:
-    - name: /etc/apt/trusted.gpg.d/saltstack.gpg
+clean.sls

--- a/salt/pkgrepo/debian/clean.sls
+++ b/salt/pkgrepo/debian/clean.sls
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "salt/map.jinja" import salt_settings with context %}
+
+salt-pkgrepo-clean-saltstack-debian:
+  pkgrepo.absent:
+    - name: {{ salt_settings.pkgrepo }}
+  file.absent:
+    - name: /etc/apt/sources.list.d/saltstack.list
+
+salt-pkgrepo-clean-saltstack-debian-apt-key:
+  file.absent:
+    - name: /etc/apt/trusted.gpg.d/saltstack.gpg

--- a/salt/pkgrepo/debian/init.sls
+++ b/salt/pkgrepo/debian/init.sls
@@ -1,12 +1,5 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+# -*- coding: utf-8 -*-
+# vim: ft=sls
 
-saltstack-pkgrepo:
-  pkgrepo.managed:
-    - humanname: SaltStack Debian Repo
-    - name: {{ salt_settings.pkgrepo }}
-    - file: /etc/apt/sources.list.d/saltstack.list
-    - key_url: {{ salt_settings.key_url }}
-    - clean_file: True
-    # Order: 1 because we can't put a require_in on "pkg: salt-{master,minion}"
-    # because we don't know if they are used.
-    - order: 1
+include:
+  - .install

--- a/salt/pkgrepo/debian/install.sls
+++ b/salt/pkgrepo/debian/install.sls
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "salt/map.jinja" import salt_settings with context %}
+
+salt-pkgrepo-install-saltstack-debian:
+  pkgrepo.managed:
+    - humanname: SaltStack Debian Repo
+    - name: {{ salt_settings.pkgrepo }}
+    - file: /etc/apt/sources.list.d/saltstack.list
+    - key_url: {{ salt_settings.key_url }}
+    - clean_file: True
+    # Order: 1 because we can't put a require_in on "pkg: salt-{master,minion}"
+    # because we don't know if they are used.
+    - order: 1

--- a/salt/pkgrepo/redhat/absent.sls
+++ b/salt/pkgrepo/redhat/absent.sls
@@ -1,3 +1,1 @@
-drop-saltstack-pkgrepo:
-  pkgrepo.absent:
-    - name: saltstack-pkgrepo
+clean.sls

--- a/salt/pkgrepo/redhat/clean.sls
+++ b/salt/pkgrepo/redhat/clean.sls
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+salt-pkgrepo-clean-saltstack-redhat:
+  pkgrepo.absent:
+    - name: saltstack

--- a/salt/pkgrepo/redhat/init.sls
+++ b/salt/pkgrepo/redhat/init.sls
@@ -1,12 +1,5 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+# -*- coding: utf-8 -*-
+# vim: ft=sls
 
-{%- if grains['os']|lower not in ('amazon', 'fedora') %}
-saltstack-pkgrepo:
-  pkgrepo.managed:
-    - name: saltstack
-    - humanname: SaltStack repo for RHEL/CentOS $releasever
-    - baseurl: {{ salt_settings.pkgrepo }}
-    - enabled: 1
-    - gpgcheck: 1
-    - gpgkey: {{ salt_settings.key_url }}
-{% endif %}
+include:
+  - .install

--- a/salt/pkgrepo/redhat/install.sls
+++ b/salt/pkgrepo/redhat/install.sls
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "salt/map.jinja" import salt_settings with context %}
+
+  {%- if grains['os']|lower not in ('amazon', 'fedora') %}
+salt-pkgrepo-install-saltstack-redhat:
+  pkgrepo.managed:
+    - name: saltstack
+    - humanname: SaltStack repo for RHEL/CentOS $releasever
+    - baseurl: {{ salt_settings.pkgrepo }}
+    - enabled: 1
+    - gpgcheck: 1
+    - gpgkey: {{ salt_settings.key_url }}
+  {% endif %}

--- a/salt/pkgrepo/suse/absent.sls
+++ b/salt/pkgrepo/suse/absent.sls
@@ -1,3 +1,1 @@
-drop-saltstack-pkgrepo:
-  pkgrepo.absent:
-    - name: saltstack-pkgrepo
+clean.sls

--- a/salt/pkgrepo/suse/clean.sls
+++ b/salt/pkgrepo/suse/clean.sls
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+salt-pkgrepo-clean-saltstack-suse:
+  pkgrepo.absent:
+    - name: systemsmanagement_saltstack_products

--- a/salt/pkgrepo/suse/init.sls
+++ b/salt/pkgrepo/suse/init.sls
@@ -1,10 +1,5 @@
-{% from "salt/map.jinja" import salt_settings with context %}
+# -*- coding: utf-8 -*-
+# vim: ft=sls
 
-saltstack-pkgrepo:
-  pkgrepo.managed:
-    - name: systemsmanagement_saltstack_products
-    - humanname: SaltStack repo for Opensuse 42.3
-    - baseurl: {{ salt_settings.pkgrepo }}
-    - enabled: 1
-    - gpgcheck: 1
-    - gpgkey: {{ salt_settings.key_url }}
+include:
+  - .install

--- a/salt/pkgrepo/suse/install.sls
+++ b/salt/pkgrepo/suse/install.sls
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "salt/map.jinja" import salt_settings with context %}
+
+salt-pkgrepo-install-saltstack-suse:
+  pkgrepo.managed:
+    - name: systemsmanagement_saltstack_products
+    - humanname: SaltStack repo for Opensuse 42.3
+    - baseurl: {{ salt_settings.pkgrepo }}
+    - enabled: 1
+    - gpgcheck: 1
+    - gpgkey: {{ salt_settings.key_url }}


### PR DESCRIPTION
This PR aligns `pkgrepo` state to template-formula.

- rename `pkgrepo.absent` to `pkgrepo.clean` (symlinked)
- rename `pkgrepo.init.sls` to `pkgrepo.install.sls` (dereferenced)
- add standard comments to each sls file
- rename state names per standard

This PR also corrects two things-
- Update README to more accurately describe what `pkgrepo` state is for.
- Update all `pkgrepo.absent` states to use **name** defined by `pkgrepo.managed`