### PR TITLE
fix(travis): disable two failing platforms until they can be fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ env:
   matrix:
     - INSTANCE: v2019-2-py3-debian-9
     - INSTANCE: v2019-2-py3-ubuntu-1804
-    - INSTANCE: v2019-2-py2-centos-7
+    # - INSTANCE: v2019-2-py2-centos-7
     - INSTANCE: v2019-2-py2-fedora-29
 
     - INSTANCE: v2018-3-py2-debian-8
     - INSTANCE: v2018-3-py2-ubuntu-1604
     - INSTANCE: v2018-3-py2-bootstrap-centos-6
     - INSTANCE: v2018-3-py2-forced-version-fedora-28
-    - INSTANCE: v2018-3-py2-opensuse-423
+    # - INSTANCE: v2018-3-py2-opensuse-423
 
     - INSTANCE: v2017-7-py2-debian-8
     - INSTANCE: v2017-7-py2-ubuntu-1604


### PR DESCRIPTION
* Every PR is currently showing as failed and `commitlint` is never running
* Disable these two platforms in the meantime; still ten platforms being tested
* `opensuse-423` is EOL in any case

---

@javierbertoli I'm going to go ahead and merge this immediately, so that we can start benefiting from testing again on our PRs.  @noelmcloughlin has a bunch of them submitted and all showing up as failures, when they're not.