### PR TITLE
fix(minion): Add 'return' to reserved_keys in minion config

### DIFF
--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -1,7 +1,7 @@
 # This file managed by Salt, do not edit by hand!!
 #  Based on salt version 2016.11 default config
 #
-{% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs', 'engines', 'beacons', 'reactors'] -%}
+{% set reserved_keys = ['master', 'minion', 'cloud', 'salt_cloud_certs', 'engines', 'beacons', 'reactors', 'return'] -%}
 {% set cfg_salt = pillar.get('salt', {}) -%}
 {% set cfg_minion = cfg_salt.get('minion', {}) -%}
 {% set default_keys = [] -%}


### PR DESCRIPTION
This prevents the `return` key being duplicated in the minion config by L1205