### PR TITLE
test(pkgs_spec): update for `2019.2.1` release

### DIFF
--- a/test/integration/v201902-py2/controls/pkgs_spec.rb
+++ b/test/integration/v201902-py2/controls/pkgs_spec.rb
@@ -1,13 +1,13 @@
 version =
   case platform[:family]
   when 'redhat'
-    '2019.2.0-1.el7'
+    '2019.2.1-1.el7'
   when 'fedora'
     '2019.2.0-1.fc30'
   when 'suse'
     '2019.2.0-lp151.5.3.1'
   when 'debian'
-    '2019.2.0+ds-1'
+    '2019.2.1+ds-1'
   end
 
 control 'salt packages' do

--- a/test/integration/v201902-py3/controls/pkgs_spec.rb
+++ b/test/integration/v201902-py3/controls/pkgs_spec.rb
@@ -5,14 +5,14 @@ version =
     when 'amazon'
       '2019.2.0-1.el7'
     when 'centos'
-      '2019.2.0-2.el7'
+      '2019.2.1-1.el7'
     end
   when 'fedora'
     '2019.2.0-1.fc30'
   when 'suse'
     '2019.2.0-lp151.5.3.1'
   when 'debian'
-    '2019.2.0+ds-1'
+    '2019.2.1+ds-1'
   end
 
 control 'salt packages' do


### PR DESCRIPTION
* https://docs.saltstack.com/en/latest/topics/releases/2019.2.1.html

---

This is needed immediately since the Travis run fails overall without it:

* https://travis-ci.org/myii/salt-formula/builds/589618332 (current)
* https://travis-ci.org/myii/salt-formula/builds/589623368 (fixed)