### PR TITLE
test(pkgs_spec): reset version from `2019.2.1` back to `2019.2.0`

### DIFF
--- a/test/integration/v201902-py2/controls/pkgs_spec.rb
+++ b/test/integration/v201902-py2/controls/pkgs_spec.rb
@@ -3,13 +3,13 @@
 version =
   case platform[:family]
   when 'redhat'
-    '2019.2.1-1.el7'
+    '2019.2.0-1.el7'
   when 'fedora'
     '2019.2.0-1.fc30'
   when 'suse'
     '2019.2.0-lp151.5.3.1'
   when 'debian'
-    '2019.2.1+ds-1'
+    '2019.2.0+ds-1'
   end
 
 control 'salt packages' do

--- a/test/integration/v201902-py3/controls/pkgs_spec.rb
+++ b/test/integration/v201902-py3/controls/pkgs_spec.rb
@@ -7,14 +7,14 @@ version =
     when 'amazon'
       '2019.2.0-1.el7'
     when 'centos'
-      '2019.2.1-1.el7'
+      '2019.2.0-2.el7'
     end
   when 'fedora'
     '2019.2.0-1.fc30'
   when 'suse'
     '2019.2.0-lp151.5.3.1'
   when 'debian'
-    '2019.2.1+ds-1'
+    '2019.2.0+ds-1'
   end
 
 control 'salt packages' do


### PR DESCRIPTION
* https://groups.google.com/forum/#!msg/salt-announce/a2kXUwwakqQ/f4sdBQpNDAAJ

---

Tested this on all relevant instances in my fork; confirmed these version numbers are working:

* https://travis-ci.org/myii/salt-formula/builds/596761647
* https://travis-ci.org/myii/salt-formula/builds/596766042 -- last one redone