### PR TITLE
fix(tpl_path): salt master conf files

### DIFF
--- a/salt/cloud.sls
+++ b/salt/cloud.sls
@@ -1,3 +1,4 @@
+{%- set tplroot = tpldir.split('/')[0] %}
 {% from "salt/map.jinja" import salt_settings with context %}
 
 {%- if salt_settings.use_pip %}
@@ -34,7 +35,7 @@ salt-cloud:
 cloud-cert-{{ cert }}-pem:
   file.managed:
     - name: {{ salt_settings.config_path }}/pki/cloud/{{ cert }}.pem
-    - source: salt://{{ slspath }}/files/key
+    - source: salt://{{ tplroot }}/files/key
     - template: jinja
     - user: root
     - group:

--- a/salt/master.sls
+++ b/salt/master.sls
@@ -24,7 +24,7 @@ salt-master:
               }}
     {%- else %}
     - template: jinja
-    - source: salt://{{ slspath }}/files/master.d
+    - source: salt://{{ tplroot }}/files/master.d
     {%- endif %}
     - clean: {{ salt_settings.clean_config_d_dir }}
     - exclude_pat: _*

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -65,7 +65,7 @@ salt-minion:
               }}
     {%- else %}
     - template: jinja
-    - source: salt://{{ slspath }}/files/minion.d
+    - source: salt://{{ tplroot }}/files/minion.d
     - context:
         standalone: False
     {%- endif %}

--- a/salt/ssh.sls
+++ b/salt/ssh.sls
@@ -1,3 +1,4 @@
+{%- set tplroot = tpldir.split('/')[0] %}
 {% from "salt/map.jinja" import salt_settings with context %}
 
 {% if salt_settings.install_packages %}
@@ -12,7 +13,7 @@ ensure-salt-ssh-is-installed:
 ensure-roster-config:
   file.managed:
     - name: {{ salt_settings.config_path }}/roster
-    - source: salt://{{ slspath }}/files/roster.jinja
+    - source: salt://{{ tplroot }}/files/roster.jinja
     - template: jinja
 {% if salt_settings.install_packages %}
     - require:

--- a/salt/standalone.sls
+++ b/salt/standalone.sls
@@ -1,3 +1,4 @@
+{%- set tplroot = tpldir.split('/')[0] %}
 {% from "salt/map.jinja" import salt_settings with context %}
 
 salt-minion:
@@ -11,7 +12,7 @@ salt-minion:
   file.recurse:
     - name: {{ salt_settings.config_path }}/minion.d
     - template: jinja
-    - source: salt://{{ slspath }}/files/minion.d
+    - source: salt://{{ tplroot }}/files/minion.d
     - clean: {{ salt_settings.clean_config_d_dir }}
     - exclude_pat: _*
     - context:


### PR DESCRIPTION
Before this fix, the `file.recurse`'s source resolved to this path:
```
source:
  salt://salt/master/files/master.d
```
whereas the path where are located tpls is :
` salt://salt/files/master.d`
Correction just replace `slspath` by `tplroot`

Also done everywhere slspath is used ..