### PR TITLE
feat(package): use apt-pinning to pin specific package version

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# FILE PATTERN                 OWNER(S)
+*                              @saltstack-formulas/wg
+salt/formulas.sls              @sticky-note @myii
+salt/pin.sls                   @hatifnatt

--- a/pillar.example
+++ b/pillar.example
@@ -24,6 +24,10 @@ salt:
   # Optional: set salt version (if install_packages is set to true)
   version: 2017.7.2-1.el7
 
+  # Pin version provided under 'version' key by using apt-pinning
+  # available only on Debian family OS-es
+  pin_version: false
+
   # to overwrite map.jinja salt packages
   lookup:
     salt_master: 'salt-master'

--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -3,6 +3,7 @@
 ---
 salt:
   version: ''
+  pin_version: false
   py_ver: ''   ## py2 is default
   rootuser: root
   rootgroup: root

--- a/salt/master.sls
+++ b/salt/master.sls
@@ -2,6 +2,11 @@
 {%- from tplroot ~ "/map.jinja" import salt_settings with context %}
 {%- from tplroot ~ "/libtofs.jinja" import files_switch with context %}
 
+{% if salt_settings.pin_version and salt_settings.version and grains.os_family|lower == 'debian' %}
+include:
+  - .pin
+{% endif %}
+
 salt-master:
 {% if salt_settings.install_packages %}
   pkg.installed:

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -2,6 +2,11 @@
 {%- from tplroot ~ "/map.jinja" import salt_settings with context %}
 {%- from tplroot ~ "/libtofs.jinja" import files_switch with context %}
 
+{% if salt_settings.pin_version and salt_settings.version and grains.os_family|lower == 'debian' %}
+include:
+  - .pin
+{% endif %}
+
 {% if salt_settings.install_packages and grains.os == 'MacOS' %}
 download-salt-minion:
     {% if salt_settings.salt_minion_pkg_source %}

--- a/salt/pin.sls
+++ b/salt/pin.sls
@@ -1,0 +1,22 @@
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import salt_settings with context %}
+
+{% if salt_settings.pin_version and salt_settings.version and grains.os_family|lower == 'debian' %}
+salt-pin-version:
+  file.managed:
+    - name: /etc/apt/preferences.d/salt
+    - contents: |
+        # This file managed by Salt, do not edit by hand!!
+        Package: salt*
+        Pin: version {{ salt_settings.version }}
+        Pin-Priority: 1000
+    # Order: 2 because we can't put a require_in on "pkg: salt-{master,minion}"
+    # because we don't know if they are used, and 'order: 1' already occupied by salt-pkgrepo
+    - order: 2
+
+{% elif grains.os_family|lower != 'debian' %}
+salt-pin-version:
+  test.show_notification:
+    - name: Available on Debian family OS-es only
+    - text: Apt pinning available only on Debian based distributives
+{% endif %}


### PR DESCRIPTION
Available only on Debian family OS-es

<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->
#314 #358


### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->
Add ability to pin version provided via pillar using apt-pinning. Benefits of version pinning:
* prevent unwanted package upgrades during system wide upgrades like `apt-get update; apt-get upgrade`
* allow package downgrade, simple version specification is not enough for downgrade because related packages won't be downgraded, i.e. if you try to downgrade from version `3000` to `2019.2.3` with `apt-get install salt-minion=2019.2.*` you will face error because apt will try to install version 3000 of `salt-common`
 
All changes applicable only to Debian based OS-es.

No test written but tested on my Debian Jessie - Buster machines successfully performed upgrade from v. 2018 to v. 2019, v. 3000 and downgrade from v. 3000  to v. 2019.

**Note**
Sometimes restart of salt-minion take a lot of time, about 2 minutes and formula execution ends with an error `Minion did not return. [No response]` checking service status with `systemctl status salt-minion.service` will retun
```
● salt-minion.service - The Salt Minion
   Loaded: loaded (/lib/systemd/system/salt-minion.service; enabled)
   Active: deactivating (stop-sigterm) since ...
```
but after some time minion became available again.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


