### PR TITLE
fix(jinja): replace version_cmp with grains lookup

### DIFF
--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -34,7 +34,7 @@
 {%-       do processed_basedirs.append(basedir) %}
 {{ basedir }}:
   file.directory:
-    - parallel: {{ salt.pkg.version_cmp(grains['saltversion'], '2017.7.0') >= 0 }}
+    - parallel: {{ grains['saltversioninfo'] >= [2017, 7, 0] }}
     {%-   for key, value in salt['pillar.get']('salt_formulas:basedir_opts',
                                                {'makedirs': True}).items() %}
     - {{ key }}: {{ value }}

--- a/salt/formulas.sls
+++ b/salt/formulas.sls
@@ -54,7 +54,7 @@
 {{ gitdir_env }}:
   git.latest:
     - name: {{ baseurl }}/{{ f_name }}.git
-    - parallel: {{ salt.pkg.version_cmp(grains['saltversion'], '2017.7.0') >= 0 }}
+    - parallel: {{ grains['saltversioninfo'] >= [2017, 7, 0] }}
     - target: {{ gitdir }}
     {%-   for key, value in options.items() %}
     - {{ key }}: {{ value }}

--- a/test/integration/v201902-py3/controls/pkgs_spec.rb
+++ b/test/integration/v201902-py3/controls/pkgs_spec.rb
@@ -12,7 +12,7 @@ version =
   when 'fedora'
     '2019.2.1rc0-3.fc31'
   when 'suse'
-    '2019.2.0-lp151.5.9.1'
+    '2019.2.0-lp151.5.12.1'
   when 'debian'
     '2019.2.3+ds-1'
   end


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?

#### Primary type

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?


No.

### Related issues and/or pull requests
Fixes #459 

### Describe the changes you're proposing

Use `grains`, more portable anyway

### Pillar / config required to test the proposed changes

```
salt_formulas:
  git_opts:
    default:
      baseurl: https://github.com/saltstack-formulas
         {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD'] %}
      basedir: /usr/local/etc/salt/states/namespaces/saltstack-formulas
         {%- else %}
      basedir: /srv/salt/namespaces/saltstack-formulas
         {%- endif %}
  basedir_opts:
    makedirs: True
    user: root
      {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD'] %}
    group: wheel
      {%- else %}
    group: root
      {%- endif %}
    mode: 755
  minion_conf:
    create_from_list: True
  list:
    base:
     {{ '- epel-formula' if grains.os_family in ('RedHat',) else '' }}
     - salt-formula
```

### Debug log showing how the proposed changes work




### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


