### PR TITLE
feat(master): enable option to set master scheduler

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -157,6 +157,12 @@ salt:
               type: runner
               cmd: jobs.list_jobs
 
+    # Define a master scheduler
+    schedule:
+      - update_winrepo:
+        - function: winrepo.update_git_repos
+        - hours: 6
+
     # optional: these reactors will be configured on the master
     # They override reactors configured in
     # 'salt:reactors' or the old 'salt:reactor' parameters

--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -124,6 +124,25 @@ module_dirs:
 # job cache and executes the scheduler.
 {{ get_config('loop_interval', '60') }}
 
+# When using the scheduler at least one schedule needs to be
+# defined. The user running the salt master will need read access to the repo.
+{% if 'schedule' in cfg_master -%}
+{%- do default_keys.append('schedule') %}
+schedule:
+{%- for schedule in cfg_master['schedule'] %}
+{%- if schedule is iterable and schedule is not string %}
+  {%- for name, children in schedule.items() %}
+    {{ name }}:
+  {%- for child in children %}
+    {%- for key, value in child.items() %}
+      {{ key }}: {{ value }}
+    {%- endfor -%}
+  {%- endfor -%}
+  {%- endfor -%}
+{%- endif -%}
+{%- endfor -%}
+{%- endif %}
+
 # Set the default outputter used by the salt command. The default is "nested".
 {{ get_config('output', 'nested') }}
 


### PR DESCRIPTION
### What type of PR is this?
Enable configuration of scheduling option on master : https://docs.saltstack.com/en/latest/topics/jobs/#scheduling-runners

#### Primary type
- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
No.

### Related issues and/or pull requests
https://github.com/saltstack-formulas/salt-formula/pull/323


### Describe the changes you're proposing
Take the same implementation than minion configuration file : https://github.com/saltstack-formulas/salt-formula/pull/323


### Documentation checklist
- [ ] Updated the `README` (e.g. `Available states`).
- [X] Updated `pillar.example`.