### PR TITLE
fix: revert to using `is mapping` in Jinja2

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -1202,8 +1202,7 @@ ext_pillar:
   {%- for key in pillar -%}
     {%- if pillar[key] is string %}
   - {{ key }}: {{ pillar[key] }}
-    {#- Workaround for missing `is mapping` on CentOS 6, see #193: #}
-    {%- elif pillar[key] is iterable and 'dict' not in pillar[key].__class__.__name__ %}
+    {%- elif pillar[key] is iterable and pillar[key] is not mapping %}
   - {{ key }}:
       {%- for parameter in pillar[key] %}
         {%- if parameter is iterable and parameter is not string %}
@@ -1219,8 +1218,7 @@ ext_pillar:
     - {{ parameter }}
         {%- endif %}
       {%- endfor -%}
-    {#- Workaround for missing `is mapping` on CentOS 6, see #193: #}
-    {%- elif 'dict' in pillar[key].__class__.__name__ and pillar[key] is not string %}
+    {%- elif pillar[key] is mapping and pillar[key] is not string %}
   - {{ key }}: 
       {%- for parameter in pillar[key] %}
       {{ parameter }}: {{pillar[key][parameter]}}

--- a/salt/files/master.d/lxc_profiles.conf
+++ b/salt/files/master.d/lxc_profiles.conf
@@ -12,8 +12,7 @@ lxc.container_profile:
 {%- for prof in cfg_prof %}
   {{ prof }}:
 {%- for conf in cfg_prof[prof] %}
-{#- Workaround for missing `is mapping` on CentOS 6, see #193 #}
-{%-   if 'dict' in cfg_prof[prof][conf].__class__.__name__ %}
+{%-   if cfg_prof[prof][conf] is mapping %}
     {{ conf }}:
 {%-      for opt in cfg_prof[prof][conf] %}
       {{ opt }}: {{ cfg_prof[prof][conf][opt] }}
@@ -30,8 +29,7 @@ lxc.network_profile:
 {%- for prof in cfg_net %}
   {{ prof }}:
 {%- for conf in cfg_net[prof] -%}
-{#- Workaround for missing `is mapping` on CentOS 6, see #193 #}
-{%-  if 'dict' in cfg_net[prof][conf].__class__.__name__ %}
+{%-   if cfg_prof[prof][conf] is mapping %}
     {{ conf }}:
 {%-      for opt in cfg_net[prof][conf] %}
       {{ opt }}: {{ cfg_net[prof][conf][opt] }}

--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -838,8 +838,7 @@ ext_pillar:
   {%- for key in pillar -%}
     {%- if pillar[key] is string %}
   - {{ key }}: {{ pillar[key] }}
-    {#- Workaround for missing `is mapping` on CentOS 6, see #193: #}
-    {%- elif pillar[key] is iterable and 'dict' not in pillar[key].__class__.__name__ %}
+    {%- elif pillar[key] is iterable and pillar[key] is not mapping %}
   - {{ key }}:
       {%- for parameter in pillar[key] %}
         {%- if parameter is iterable and parameter is not string %}
@@ -855,8 +854,7 @@ ext_pillar:
     - {{ parameter }}
         {%- endif %}
       {%- endfor -%}
-    {#- Workaround for missing `is mapping` on CentOS 6, see #193: #}
-    {%- elif 'dict' in pillar[key].__class__.__name__ and pillar[key] is not string %}
+    {%- elif pillar[key] is mapping and pillar[key] is not string %}
   - {{ key }}:
       {%- for parameter in pillar[key] %}
       {{ parameter }}: {{pillar[key][parameter]}}

--- a/test/integration/v3000-py2/files/_mapdata/ubuntu-16.yaml
+++ b/test/integration/v3000-py2/files/_mapdata/ubuntu-16.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/apt/ubuntu/16.04/amd64/3000/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py2/files/_mapdata/ubuntu-18.yaml
+++ b/test/integration/v3000-py2/files/_mapdata/ubuntu-18.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/apt/ubuntu/18.04/amd64/3000/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/amazonlinux-2.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/amazonlinux-2.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/amazon/2/$basearch/3000/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/centos-7.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/centos-7.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3000/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/centos-8.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/centos-8.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3000/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/debian-10.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/debian-10.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/debian/10/amd64/3000/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/debian-9.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/debian-9.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/debian/9/amd64/3000/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/gentoo-2-sysd.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/gentoo-2-sysd.yaml
@@ -43,6 +43,13 @@ values:
         version: 0.23.0
     install_packages: true
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/gentoo-2-sysv.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/gentoo-2-sysv.yaml
@@ -43,6 +43,13 @@ values:
         version: 0.23.0
     install_packages: true
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/opensuse-15.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/opensuse-15.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://download.opensuse.org/repositories/systemsmanagement:/saltstack/openSUSE_Leap_15.2/repodata/repomd.xml.key
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/oraclelinux-7.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/oraclelinux-7.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3000/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/oraclelinux-8.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/oraclelinux-8.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3000/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/ubuntu-16.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/ubuntu-16.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/ubuntu/16.04/amd64/3000/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/ubuntu-18.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/ubuntu-18.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/ubuntu/18.04/amd64/3000/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3000-py3/files/_mapdata/windows-2019-server.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/windows-2019-server.yaml
@@ -43,6 +43,13 @@ values:
         version: 0.23.0
     install_packages: true
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - "/srv/salt"

--- a/test/integration/v3000-py3/files/_mapdata/windows-8.yaml
+++ b/test/integration/v3000-py3/files/_mapdata/windows-8.yaml
@@ -43,6 +43,13 @@ values:
         version: 0.23.0
     install_packages: true
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - "/srv/salt"

--- a/test/integration/v3001-py3/files/_mapdata/amazonlinux-2.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/amazonlinux-2.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/amazon/2/$basearch/3001/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/centos-7.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/centos-7.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3001/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/centos-8.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/centos-8.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3001/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/debian-10.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/debian-10.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/debian/10/amd64/3001/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/debian-9.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/debian-9.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/debian/9/amd64/3001/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/fedora-32.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/fedora-32.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3001/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/fedora-33.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/fedora-33.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3001/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/gentoo-2-sysd.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/gentoo-2-sysd.yaml
@@ -43,6 +43,13 @@ values:
         version: 0.23.0
     install_packages: true
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/gentoo-2-sysv.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/gentoo-2-sysv.yaml
@@ -43,6 +43,13 @@ values:
         version: 0.23.0
     install_packages: true
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/opensuse-15.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/opensuse-15.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://download.opensuse.org/repositories/systemsmanagement:/saltstack/openSUSE_Leap_15.2/repodata/repomd.xml.key
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/opensuse-tumbleweed.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/opensuse-tumbleweed.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://download.opensuse.org/repositories/systemsmanagement:/saltstack/openSUSE_Tumbleweed/repodata/repomd.xml.key
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/oraclelinux-7.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/oraclelinux-7.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3001/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/oraclelinux-8.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/oraclelinux-8.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3001/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/ubuntu-16.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/ubuntu-16.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/ubuntu/16.04/amd64/3001/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/ubuntu-18.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/ubuntu-18.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/ubuntu/18.04/amd64/3001/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3001-py3/files/_mapdata/ubuntu-20.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/ubuntu-20.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/ubuntu/20.04/amd64/3001/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/amazonlinux-2.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/amazonlinux-2.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/amazon/2/$basearch/3002/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/centos-7.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/centos-7.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3002/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/centos-8.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/centos-8.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3002/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/debian-10.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/debian-10.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/debian/10/amd64/3002/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/debian-9.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/debian-9.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/debian/9/amd64/3002/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/fedora-32.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/fedora-32.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3002/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/fedora-33.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/fedora-33.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3002/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/gentoo-2-sysd.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/gentoo-2-sysd.yaml
@@ -43,6 +43,13 @@ values:
         version: 0.23.0
     install_packages: true
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/gentoo-2-sysv.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/gentoo-2-sysv.yaml
@@ -43,6 +43,13 @@ values:
         version: 0.23.0
     install_packages: true
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/opensuse-15.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/opensuse-15.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://download.opensuse.org/repositories/systemsmanagement:/saltstack/openSUSE_Leap_15.2/repodata/repomd.xml.key
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/opensuse-tumbleweed.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/opensuse-tumbleweed.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://download.opensuse.org/repositories/systemsmanagement:/saltstack/openSUSE_Tumbleweed/repodata/repomd.xml.key
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/oraclelinux-7.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/oraclelinux-7.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3002/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/oraclelinux-8.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/oraclelinux-8.yaml
@@ -44,6 +44,13 @@ values:
     install_packages: true
     key_url: https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3002/SALTSTACK-GPG-KEY.pub
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/ubuntu-16.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/ubuntu-16.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/ubuntu/16.04/amd64/3002/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/ubuntu-18.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/ubuntu-18.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/ubuntu/18.04/amd64/3002/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/integration/v3002-py3/files/_mapdata/ubuntu-20.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/ubuntu-20.yaml
@@ -45,6 +45,13 @@ values:
     key_url: https://repo.saltstack.com/py3/ubuntu/20.04/amd64/3002/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
+      ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
       file_roots:
         base:
         - /srv/salt

--- a/test/salt/pillar/salt.sls
+++ b/test/salt/pillar/salt.sls
@@ -11,6 +11,13 @@ salt:
     pillar_roots:
       base:
         - /srv/pillar
+    ext_pillar:
+      - cmd_yaml: cat /etc/salt/yaml
+      - stack:
+          - /path/to/stack1.cfg
+          - /path/to/stack2.cfg
+      - reclass:
+          inventory_base_uri: /etc/reclass
   minion:
     master: localhost
     fileserver_backend:


### PR DESCRIPTION


<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

* In `v3002.5` (and probably other patched versions), the fix for CVE-2021-25283 enables Jinja2 safe mode, which breaks use of  the `'dict' in x.__class__.__name__` workaround
* Workaround no longer needed as CentOS 6 is EOL



### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

```
salt:
  master:
    ext_pillar:
      - cmd_yaml: cat /etc/salt/yaml
      - git:
          - develop https://gitserver/git-pillar.git:
              - env: base
      - reclass:
          inventory_base_uri: /etc/reclass
```

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
Unable to manage file: Jinja syntax error: access to attribute '__class__' of 'list' object is unsafe.; line 1206
              
              ---
              [...]
              {%- for pillar in cfg_master['ext_pillar'] -%}
                {%- for key in pillar -%}
                  {%- if pillar[key] is string %}
                - {{ key }}: {{ pillar[key] }}
                  {#- Workaround for missing `is mapping` on CentOS 6, see #193: #}
                  {%- elif pillar[key] is iterable and 'dict' not in pillar[key].__class__.__name__ %}    <======================
                - {{ key }}:
                    {%- for parameter in pillar[key] %}
                      {%- if parameter is iterable and parameter is not string %}
                      {%- for param, children in parameter.items() %}
                  - {{ param }}:
              [...]
              ---
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [x] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


