### PR TITLE
Fix repo management on Debian Bullseye and newer.

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -14,7 +14,7 @@ salt:
   master_remove_config: true
 
   # Set this to 'py3' to install the Python 3 packages.
-  # If this is not set, the Python 2 packages will be installed by default.
+  # The default varies between OS versions.
   py_ver: 'py3'
 
   # Set this to false to not have the formula install packages (in the case you

--- a/salt/osfamilymap.yaml
+++ b/salt/osfamilymap.yaml
@@ -25,9 +25,8 @@
 
 
 Debian:
-  pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
-  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
-  pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }}/salt-archive-keyring.gpg'
+  pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
+  pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }}/salt-archive-keyring.gpg'
   pkgrepo_keyring_hash: sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47
   libgit2: libgit2-22
   pyinotify: python-pyinotify

--- a/salt/osmap.yaml
+++ b/salt/osmap.yaml
@@ -38,8 +38,8 @@ Ubuntu:
         install_from_package: Null
 
 Raspbian:
-  pkgrepo: 'deb {{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_family_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }} {{ oscodename }} main'
-  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_family_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
+  pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=armhf] {{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ os_family_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }} {{ oscodename }} main'
+  pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ os_family_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }}/salt-archive-keyring.gpg'
 
 SmartOS:
   salt_master: salt

--- a/salt/pkgrepo/debian/install.sls
+++ b/salt/pkgrepo/debian/install.sls
@@ -21,7 +21,9 @@ salt-pkgrepo-install-saltstack-debian:
     - humanname: SaltStack Debian Repo
     - name: {{ salt_settings.pkgrepo }}
     - file: /etc/apt/sources.list.d/salt.list
+    {% if salt_settings.get('key_url') is not none %}
     - key_url: {{ salt_settings.key_url }}
+    {% endif %}
     - clean_file: True
     # Order: 3 because we can't put a require_in on "pkg: salt-{master,minion}"
     # because we don't know if they are used.

--- a/test/integration/v3001-py3/files/_mapdata/debian-10.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/debian-10.yaml
@@ -42,7 +42,6 @@ values:
           version: 0.23.0
         version: 0.22.1
     install_packages: true
-    key_url: https://repo.saltproject.io/py3/debian/10/amd64/3001/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
       ext_pillar:

--- a/test/integration/v3001-py3/files/_mapdata/debian-9.yaml
+++ b/test/integration/v3001-py3/files/_mapdata/debian-9.yaml
@@ -42,7 +42,6 @@ values:
           version: 0.23.0
         version: 0.22.1
     install_packages: true
-    key_url: https://repo.saltproject.io/py3/debian/9/amd64/3001/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
       ext_pillar:

--- a/test/integration/v3002-py3/files/_mapdata/debian-10.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/debian-10.yaml
@@ -42,7 +42,6 @@ values:
           version: 0.23.0
         version: 0.22.1
     install_packages: true
-    key_url: https://repo.saltproject.io/py3/debian/10/amd64/3002/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
       ext_pillar:

--- a/test/integration/v3002-py3/files/_mapdata/debian-9.yaml
+++ b/test/integration/v3002-py3/files/_mapdata/debian-9.yaml
@@ -42,7 +42,6 @@ values:
           version: 0.23.0
         version: 0.22.1
     install_packages: true
-    key_url: https://repo.saltproject.io/py3/debian/9/amd64/3002/SALTSTACK-GPG-KEY.pub
     libgit2: libgit2-22
     master:
       ext_pillar:


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

Considering that signed-by was already the default, limiting the default repo config to Stretch and newer, there should be none. 

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->
See commit message. Update to modern defaults for Debian and Raspbian. Fix issue with custom repos in Bullseye.


### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->
salt:py_ver: py3 can be removed on most Debian installs.

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->
Repo management succeeds by default on Rasbian and Debian Bullseye.

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


