### PR TITLE
MacOS compatibility

### DIFF
--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -24,7 +24,7 @@ download-salt-minion:
     - group: wheel
     - mode: '0644'
     - unless:
-      - test -n "{{ salt_settings.version }}" && '/opt/salt/bin/salt-minion --version=.*{{ salt_settings.version }}.*'
+      - test -n "{{ salt_settings.version }}" && /opt/salt/bin/salt-minion --version | grep -E '{{ salt_settings.version }}$'
     - require_in:
       - macpackage: salt-minion
     - retry: {{ salt_settings.retry_options | json }}
@@ -58,7 +58,7 @@ salt-minion:
            {# macpackage.installed is weird with version_check, detects diff but incomplete install #}
     - force: True    {# workaround #}
     - unless:
-      - test -n "{{ salt_settings.version }}" && '/opt/salt/bin/salt-minion --version=.*{{ salt_settings.version }}.*'
+      - test -n "{{ salt_settings.version }}" && /opt/salt/bin/salt-minion --version | grep -E '{{ salt_settings.version }}$'
            {% if salt_settings.minion_service_details.state != 'ignore' %}
     - require_in:
       - service: salt-minion

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -64,7 +64,7 @@ salt-minion:
       - service: salt-minion
            {% endif %}
     - onchanges_in:
-      - cmd: remove-macpackage-salt
+      - file: remove-macpackage-salt
         {%- elif grains.os != 'MacOS' and "workaround https://github.com/saltstack/salt/issues/49348" %}
   pkg.installed:
     - name: {{ salt_settings.salt_minion }}

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -198,7 +198,7 @@ permissions-minion-config:
     - name: {{ salt_settings.config_path | path_join('minion') }}
     - user: {{ salt_settings.rootuser }}
     - group:
-        {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD'] %}
+        {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD', 'Darwin'] %}
         wheel
         {%- else %}
         root
@@ -218,7 +218,7 @@ salt-minion-pki-dir:
 {% endif %}
     - user: {{ salt_settings.rootuser }}
     - group:
-        {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD'] %}
+        {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD', 'Darwin'] %}
         wheel
         {%- else %}
         root
@@ -237,7 +237,7 @@ permissions-minion.pem:
 {% endif %}
     - user: {{ salt_settings.rootuser }}
     - group:
-        {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD'] %}
+        {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD', 'Darwin'] %}
         wheel
         {%- else %}
         root
@@ -258,7 +258,7 @@ permissions-minion.pub:
 {% endif %}
     - user: {{ salt_settings.rootuser }}
     - group:
-        {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD'] %}
+        {%- if grains['kernel'] in ['FreeBSD', 'OpenBSD', 'NetBSD', 'Darwin'] %}
         wheel
         {%- else %}
         root


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
I did not open issues for both fixes since the cause is evident.
1. `remove-macpackage-salt` uses `file.absent`, but is referenced by `salt-minion` `onchanges_in` requisite as `cmd: remove-macpackage-salt`
2. There is no group `root` on MacOS:
```console
----------
          ID: permissions-minion-config
    Function: file.managed
        Name: /private/etc/salt/minion
      Result: False
     Comment: Group root is not available
     Started: 09:04:11.330316
    Duration: 2.895 ms
```
3. The `unless` requisites on two MacOS-specific states always evaluate to false, causing a reinstall on every run on MacOS. This is caused by an incorrect shell command.


### Describe the changes you're proposing
* Fix faulty `onchanges_in` requisite on `salt-minion` for `remove-macpackage-salt`.
* Include MacOS in the list of OS where the root user's primary group is `wheel` (correction: `staff`, but wheel exists at least. correction^2: It is `wheel`, `staff` is the admin user's primary group).
* Fix incorrect `unless` shell command on `salt-minion` and `download-salt-minion` on MacOS.


### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
There is no test suite for MacOS.

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


