### PR TITLE
Fix `salt.pkgrepo` state

### DIFF
--- a/salt/osfamilymap.yaml
+++ b/salt/osfamilymap.yaml
@@ -44,9 +44,10 @@
 
 
 Debian:
-  pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
+  pkgrepo: 'deb [signed-by=/usr/share/keyrings/{{ salt_repo_keyring_filename }} arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
   pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }}/{{ salt_repo_keyring_filename }}' #' <- vim syntax highlight fix
   pkgrepo_keyring_hash: {{ salt_repo_keyring_hash }}
+  pkgrepo_keyring_filename: {{ salt_repo_keyring_filename }}
   libgit2: libgit2-22
   pyinotify: python-pyinotify
   gitfs:

--- a/salt/osfamilymap.yaml
+++ b/salt/osfamilymap.yaml
@@ -16,7 +16,7 @@
 
 # Different salt versions have different repo's, keyrings, pubkeys and hashes.
 # 'latest' cannot be coerced into an integer and it's result will be int(0).
-{%- if salt_release.split('.')[0] | int >= 3005 or salt_release.split('.')[0] | int == 0 %}
+{%- if salt_release.split('.')[0] | int >= 3006 or salt_release.split('.')[0] | int == 0 %}
 {%-   set default_repo                  = 'https://repo.saltproject.io/salt' %}
 {%-   set default_repo_keyring_filename = 'SALT-PROJECT-GPG-PUBKEY-2023.gpg' %}
 {%-   set default_repo_pubkey_filename  = 'SALT-PROJECT-GPG-PUBKEY-2023.pub' %}

--- a/salt/osfamilymap.yaml
+++ b/salt/osfamilymap.yaml
@@ -33,7 +33,6 @@
 {%- set salt_repo_keyring_hash     = salt['pillar.get']('salt:repo_keyring_hash', default_repo_keyring_hash) %}
 
 
-
 #from template-formula
 {%- if grains.os_family == 'MacOS' %}
 {%-   set rootuser = salt['cmd.run']("stat -f '%Su' /dev/console") %}
@@ -63,8 +62,8 @@ Debian:
 RedHat:
   pkgrepo_name: saltstack
   pkgrepo_humanname: SaltStack repo for RHEL/CentOS $releasever
-  pkgrepo: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/redhat/$releasever/$basearch/{{ salt_release }}'
-  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/redhat/$releasever/$basearch/{{ salt_release }}/{{ salt_repo_pubkey_filename }}'
+  pkgrepo: '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/redhat/$releasever/$basearch/{{ salt_release }}'
+  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/redhat/$releasever/$basearch/{{ salt_release }}/{{ salt_repo_pubkey_filename }}'
   pygit2: python-pygit2
   python_git: GitPython
   gitfs:

--- a/salt/osfamilymap.yaml
+++ b/salt/osfamilymap.yaml
@@ -5,7 +5,7 @@
 {%- set py_ver_repr = salt['pillar.get']('salt:py_ver', '') %}
 
 {%- set osrelease = salt['grains.get']('osrelease', '') %}
-{%- set salt_release = salt['pillar.get']('salt:release', 'latest') %}
+{%- set salt_release = salt['pillar.get']('salt:release', 'latest') | string %}
 {%- if salt_release.split('.')|length >= 3 %}
 {%-   set salt_release = 'archive/' ~ salt_release %}
 {%- endif %}
@@ -13,7 +13,26 @@
 {%- set osmajorrelease = salt['grains.get']('osmajorrelease', osrelease)|string %}
 {%- set oscodename = salt['grains.get']('oscodename') %}
 {%- set opensuse_repo_suffix = 'Leap_' ~ osrelease if salt['grains.get']('osfinger', '') == 'Leap-15' else 'Tumbleweed' %}
-{%- set salt_repo = salt['pillar.get']('salt:repo', 'https://repo.saltproject.io') %}
+
+# Different salt versions have different repo's, keyrings, pubkeys and hashes.
+# 'latest' cannot be coerced into an integer and it's result will be int(0).
+{%- if salt_release.split('.')[0] | int >= 3005 or salt_release.split('.')[0] | int == 0 %}
+{%-   set default_repo                  = 'https://repo.saltproject.io/salt' %}
+{%-   set default_repo_keyring_filename = 'SALT-PROJECT-GPG-PUBKEY-2023.gpg' %}
+{%-   set default_repo_pubkey_filename  = 'SALT-PROJECT-GPG-PUBKEY-2023.pub' %}
+{%-   set default_repo_keyring_hash     = 'sha256=c6f6cbcd96fdb130b1dde8dcfc05d46a3a3f322ff0514f98e2e6473896243472' %}
+{%- else %}
+{%-   set default_repo                  = 'https://repo.saltproject.io' %}
+{%-   set default_repo_keyring_filename = 'salt-archive-keyring.gpg' %}
+{%-   set default_repo_pubkey_filename  = 'SALTSTACK-GPG-KEY.pub' %}
+{%-   set default_repo_keyring_hash     = 'sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47' %}
+{%- endif %}
+{%- set salt_repo                  = salt['pillar.get']('salt:repo', default_repo) %}
+{%- set salt_repo_keyring_filename = salt['pillar.get']('salt:repo_keyring_filename', default_repo_keyring_filename) %}
+{%- set salt_repo_pubkey_filename  = salt['pillar.get']('salt:repo_keyring_filename', default_repo_pubkey_filename) %}
+{%- set salt_repo_keyring_hash     = salt['pillar.get']('salt:repo_keyring_hash', default_repo_keyring_hash) %}
+
+
 
 #from template-formula
 {%- if grains.os_family == 'MacOS' %}
@@ -26,8 +45,8 @@
 
 Debian:
   pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
-  pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }}/salt-archive-keyring.gpg'
-  pkgrepo_keyring_hash: sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47
+  pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }}/{{ salt_repo_keyring_filename }}' #' <- vim syntax highlight fix
+  pkgrepo_keyring_hash: {{ salt_repo_keyring_hash }}
   libgit2: libgit2-22
   pyinotify: python-pyinotify
   gitfs:
@@ -44,7 +63,7 @@ RedHat:
   pkgrepo_name: saltstack
   pkgrepo_humanname: SaltStack repo for RHEL/CentOS $releasever
   pkgrepo: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/redhat/$releasever/$basearch/{{ salt_release }}'
-  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/redhat/$releasever/$basearch/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
+  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/redhat/$releasever/$basearch/{{ salt_release }}/{{ salt_repo_pubkey_filename }}'
   pygit2: python-pygit2
   python_git: GitPython
   gitfs:

--- a/salt/osfingermap.yaml
+++ b/salt/osfingermap.yaml
@@ -14,7 +14,7 @@
 
 # Different salt versions have different repo's, keyrings, pubkeys and hashes.
 # 'latest' cannot be coerced into an integer and it's result will be int(0).
-{%- if salt_release.split('.')[0] | int >= 3005 or salt_release.split('.')[0] | int == 0 %}
+{%- if salt_release.split('.')[0] | int >= 3006 or salt_release.split('.')[0] | int == 0 %}
 {%-   set default_repo                  = 'https://repo.saltproject.io/salt' %}
 {%-   set default_repo_keyring_filename = 'SALT-PROJECT-GPG-PUBKEY-2023.gpg' %}
 {%-   set default_repo_pubkey_filename  = 'SALT-PROJECT-GPG-PUBKEY-2023.pub' %}

--- a/salt/osfingermap.yaml
+++ b/salt/osfingermap.yaml
@@ -5,14 +5,32 @@
 {%- set py_ver_repr = salt['pillar.get']('salt:py_ver', '') %}
 
 {%- set osrelease = salt['grains.get']('osrelease', '') %}
-{%- set salt_release = salt['pillar.get']('salt:release', 'latest') %}
+{%- set salt_release = salt['pillar.get']('salt:release', 'latest') | string %}
 {%- if salt_release.split('.')|length >= 3 %}
 {%-   set salt_release = 'archive/' ~ salt_release %}
 {%- endif %}
 {%- set osmajorrelease = salt['grains.get']('osmajorrelease', osrelease)|string %}
 {%- set salt_repo = salt['pillar.get']('salt:repo', 'https://repo.saltproject.io') %}
 
+# Different salt versions have different repo's, keyrings, pubkeys and hashes.
+# 'latest' cannot be coerced into an integer and it's result will be int(0).
+{%- if salt_release.split('.')[0] | int >= 3005 or salt_release.split('.')[0] | int == 0 %}
+{%-   set default_repo                  = 'https://repo.saltproject.io/salt' %}
+{%-   set default_repo_keyring_filename = 'SALT-PROJECT-GPG-PUBKEY-2023.gpg' %}
+{%-   set default_repo_pubkey_filename  = 'SALT-PROJECT-GPG-PUBKEY-2023.pub' %}
+{%-   set default_repo_keyring_hash     = 'sha256=c6f6cbcd96fdb130b1dde8dcfc05d46a3a3f322ff0514f98e2e6473896243472' %}
+{%- else %}
+{%-   set default_repo                  = 'https://repo.saltproject.io' %}
+{%-   set default_repo_keyring_filename = 'salt-archive-keyring.gpg' %}
+{%-   set default_repo_pubkey_filename  = 'SALTSTACK-GPG-KEY.pub' %}
+{%-   set default_repo_keyring_hash     = 'sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47' %}
+{%- endif %}
+{%- set salt_repo                  = salt['pillar.get']('salt:repo', default_repo) %}
+{%- set salt_repo_keyring_filename = salt['pillar.get']('salt:repo_keyring_filename', default_repo_keyring_filename) %}
+{%- set salt_repo_pubkey_filename  = salt['pillar.get']('salt:repo_keyring_filename', default_repo_pubkey_filename) %}
+{%- set salt_repo_keyring_hash     = salt['pillar.get']('salt:repo_keyring_hash', default_repo_keyring_hash) %}
+
 Oracle Linux Server-7:
   pkgrepo_humanname: SaltStack repo for RHEL/CentOS {{ osmajorrelease }}
   pkgrepo: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/redhat/{{ osmajorrelease }}/$basearch/{{ salt_release }}'
-  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/redhat/{{ osmajorrelease }}/$basearch/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
+  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/redhat/{{ osmajorrelease }}/$basearch/{{ salt_release }}/{{ salt_repo_pubkey_filename }}'

--- a/salt/osmap.yaml
+++ b/salt/osmap.yaml
@@ -2,7 +2,6 @@
 # vim: ft=yaml
 ---
 
-{%- set py_ver_repr = salt['pillar.get']('salt:py_ver', '') %}
 
 {%- set osrelease = salt['grains.get']('osrelease', '') %}
 {%- set salt_release = salt['pillar.get']('salt:release', 'latest') | string %}
@@ -22,16 +21,29 @@
 {%-   set default_repo_keyring_filename = 'SALT-PROJECT-GPG-PUBKEY-2023.gpg' %}
 {%-   set default_repo_pubkey_filename  = 'SALT-PROJECT-GPG-PUBKEY-2023.pub' %}
 {%-   set default_repo_keyring_hash     = 'sha256=c6f6cbcd96fdb130b1dde8dcfc05d46a3a3f322ff0514f98e2e6473896243472' %}
+{%-   set default_pyver_or_apt          = 'py3' %}
+{%-   set default_pyver_or_yum          = 'py3' %}
 {%- else %}
 {%-   set default_repo                  = 'https://repo.saltproject.io' %}
 {%-   set default_repo_keyring_filename = 'salt-archive-keyring.gpg' %}
 {%-   set default_repo_pubkey_filename  = 'SALTSTACK-GPG-KEY.pub' %}
 {%-   set default_repo_keyring_hash     = 'sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47' %}
+{%-   set default_pyver_or_apt          = 'apt' %}
+{%-   set default_pyver_or_yum          = 'yum' %}
 {%- endif %}
 {%- set salt_repo                  = salt['pillar.get']('salt:repo', default_repo) %}
 {%- set salt_repo_keyring_filename = salt['pillar.get']('salt:repo_keyring_filename', default_repo_keyring_filename) %}
 {%- set salt_repo_pubkey_filename  = salt['pillar.get']('salt:repo_keyring_filename', default_repo_pubkey_filename) %}
 {%- set salt_repo_keyring_hash     = salt['pillar.get']('salt:repo_keyring_hash', default_repo_keyring_hash) %}
+
+{%- if os_family_lower in ["amazon"] %}
+{%-   set py_ver_repr = salt['pillar.get']('salt:py_ver', default_pyver_or_yum) %}
+{%- elif os_family_lower in ["ubuntu", "raspbian"] %}
+{%-   set py_ver_repr = salt['pillar.get']('salt:py_ver', default_pyver_or_apt) %}
+{%- else %}
+{%-   set py_ver_repr = 'py3' %}
+{%- endif %}
+
 
 
 Fedora:

--- a/salt/osmap.yaml
+++ b/salt/osmap.yaml
@@ -56,7 +56,7 @@ Amazon:
   key_url: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/amazon/2/$basearch/{{ salt_release }}/{{ salt_repo_pubkey_filename }}'
 
 Ubuntu:
-  pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
+  pkgrepo: 'deb [signed-by=/usr/share/keyrings/{{ salt_repo_keyring_filename}} arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
   pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/{{ salt_repo_keyring_filename }}'
   pkgrepo_keyring_hash: '{{ salt_repo_keyring_hash }}'
   key_url: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/{{ salt_repo_keyring_filename }}'
@@ -69,7 +69,7 @@ Ubuntu:
         install_from_package: Null
 
 Raspbian:
-  pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=armhf] {{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ os_family_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }} {{ oscodename }} main'
+  pkgrepo: 'deb [signed-by=/usr/share/keyrings/{{ salt_repo_keyring_filename }} arch=armhf] {{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ os_family_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }} {{ oscodename }} main'
   pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ os_family_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }}/{{ salt_repo_keyring_filename }}'
 
 SmartOS:

--- a/salt/osmap.yaml
+++ b/salt/osmap.yaml
@@ -57,8 +57,8 @@ Amazon:
 
 Ubuntu:
   pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
-  pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/salt-archive-keyring.gpg'
-  pkgrepo_keyring_hash: sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47
+  pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/{{ salt_repo_keyring_filename }}'
+  pkgrepo_keyring_hash: '{{ salt_repo_keyring_hash }}'
   key_url: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/{{ salt_repo_keyring_filename }}'
   pygit2: python-pygit2
   gitfs:

--- a/salt/osmap.yaml
+++ b/salt/osmap.yaml
@@ -5,7 +5,7 @@
 {%- set py_ver_repr = salt['pillar.get']('salt:py_ver', '') %}
 
 {%- set osrelease = salt['grains.get']('osrelease', '') %}
-{%- set salt_release = salt['pillar.get']('salt:release', 'latest') %}
+{%- set salt_release = salt['pillar.get']('salt:release', 'latest') | string %}
 {%- if salt_release.split('.')|length >= 3 %}
 {%-   set salt_release = 'archive/' ~ salt_release %}
 {%- endif %}
@@ -15,6 +15,25 @@
 {%- set os_family_lower =  salt['grains.get']('os_family')|lower %}
 {%- set salt_repo = salt['pillar.get']('salt:repo', 'https://repo.saltproject.io') %}
 
+# Different salt versions have different repo's, keyrings, pubkeys and hashes.
+# 'latest' cannot be coerced into an integer and it's result will be int(0).
+{%- if salt_release.split('.')[0] | int >= 3005 or salt_release.split('.')[0] | int == 0 %}
+{%-   set default_repo                  = 'https://repo.saltproject.io/salt' %}
+{%-   set default_repo_keyring_filename = 'SALT-PROJECT-GPG-PUBKEY-2023.gpg' %}
+{%-   set default_repo_pubkey_filename  = 'SALT-PROJECT-GPG-PUBKEY-2023.pub' %}
+{%-   set default_repo_keyring_hash     = 'sha256=c6f6cbcd96fdb130b1dde8dcfc05d46a3a3f322ff0514f98e2e6473896243472' %}
+{%- else %}
+{%-   set default_repo                  = 'https://repo.saltproject.io' %}
+{%-   set default_repo_keyring_filename = 'salt-archive-keyring.gpg' %}
+{%-   set default_repo_pubkey_filename  = 'SALTSTACK-GPG-KEY.pub' %}
+{%-   set default_repo_keyring_hash     = 'sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47' %}
+{%- endif %}
+{%- set salt_repo                  = salt['pillar.get']('salt:repo', default_repo) %}
+{%- set salt_repo_keyring_filename = salt['pillar.get']('salt:repo_keyring_filename', default_repo_keyring_filename) %}
+{%- set salt_repo_pubkey_filename  = salt['pillar.get']('salt:repo_keyring_filename', default_repo_pubkey_filename) %}
+{%- set salt_repo_keyring_hash     = salt['pillar.get']('salt:repo_keyring_hash', default_repo_keyring_hash) %}
+
+
 Fedora:
   pygit2: python2-pygit2
 
@@ -22,13 +41,13 @@ Amazon:
   pkgrepo_name: saltstack-amzn-repo
   pkgrepo_humanname: SaltStack repo for Amazon Linux 2
   pkgrepo: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/amazon/2/$basearch/{{ salt_release }}'
-  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/amazon/2/$basearch/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
+  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/amazon/2/$basearch/{{ salt_release }}/{{ salt_repo_pubkey_filename }}'
 
 Ubuntu:
   pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
   pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/salt-archive-keyring.gpg'
   pkgrepo_keyring_hash: sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47
-  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
+  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/{{ salt_repo_keyring_filename }}'
   pygit2: python-pygit2
   gitfs:
     pygit2:
@@ -39,7 +58,7 @@ Ubuntu:
 
 Raspbian:
   pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=armhf] {{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ os_family_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }} {{ oscodename }} main'
-  pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ os_family_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }}/salt-archive-keyring.gpg'
+  pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ os_family_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }}/{{ salt_repo_keyring_filename }}'
 
 SmartOS:
   salt_master: salt

--- a/salt/osmap.yaml
+++ b/salt/osmap.yaml
@@ -16,7 +16,7 @@
 
 # Different salt versions have different repo's, keyrings, pubkeys and hashes.
 # 'latest' cannot be coerced into an integer and it's result will be int(0).
-{%- if salt_release.split('.')[0] | int >= 3005 or salt_release.split('.')[0] | int == 0 %}
+{%- if salt_release.split('.')[0] | int >= 3006 or salt_release.split('.')[0] | int == 0 %}
 {%-   set default_repo                  = 'https://repo.saltproject.io/salt' %}
 {%-   set default_repo_keyring_filename = 'SALT-PROJECT-GPG-PUBKEY-2023.gpg' %}
 {%-   set default_repo_pubkey_filename  = 'SALT-PROJECT-GPG-PUBKEY-2023.pub' %}

--- a/salt/osmap.yaml
+++ b/salt/osmap.yaml
@@ -59,7 +59,7 @@ Ubuntu:
   pkgrepo: 'deb [signed-by=/usr/share/keyrings/{{ salt_repo_keyring_filename}} arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
   pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/{{ salt_repo_keyring_filename }}'
   pkgrepo_keyring_hash: '{{ salt_repo_keyring_hash }}'
-  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/{{ salt_repo_keyring_filename }}'
+  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/{{ salt_repo_pubkey_filename }}'
   pygit2: python-pygit2
   gitfs:
     pygit2:

--- a/salt/pkgrepo/debian/install.sls
+++ b/salt/pkgrepo/debian/install.sls
@@ -4,7 +4,7 @@
 
 salt-pkgrepo-install-saltstack-debian-keyring:
   file.managed:
-    - name: /usr/share/keyrings/salt-archive-keyring.gpg
+    - name: /usr/share/keyrings/{{ salt_settings.pkgrepo_keyring_filename }}
     - source: {{ salt_settings.pkgrepo_keyring }}
     - source_hash: {{ salt_settings.pkgrepo_keyring_hash }}
     - require_in:

--- a/salt/pkgrepo/debian/install.sls
+++ b/salt/pkgrepo/debian/install.sls
@@ -2,6 +2,12 @@
 # vim: ft=sls
 {% from "salt/map.jinja" import salt_settings with context %}
 
+salt-pkgrepo-install-dependency-gnupg:
+  pkg.installed:
+    - name: gnupg
+    - require_in:
+      - file: salt-pkgrepo-install-saltstack-debian-keyring
+
 salt-pkgrepo-install-saltstack-debian-keyring:
   file.managed:
     - name: /usr/share/keyrings/{{ salt_settings.pkgrepo_keyring_filename }}


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

Hopefully not :) :crossed_fingers: 

### Related issues and/or pull requests
#545 



### Describe the changes you're proposing
- when pillar key `salt.release` >= 3006 or `latest` set appropriate values for keyrings, repo paths, pubkeys.
- Add `gnupg` dependency install for ubuntu/debian.



### Pillar / config required to test the proposed changes
```
salt:
  release: 3006 # 3007 or 'latest' would test the new style. 
```
```
salt:
  release: 3005 # or lower would test the old style.
```


### Debug log showing how the proposed changes work
using pillar:
```
salt:
  release: latest
```

output:
```
[INFO    ] Loading Saltfile from '/root/.salt/Saltfile'
[DEBUG   ] Reading configuration from /root/.salt/Saltfile
[DEBUG   ] Reading configuration from /etc/salt/minion
[DEBUG   ] Including configuration from '/etc/salt/minion.d/00_bootstrap.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/00_bootstrap.conf
[DEBUG   ] Changed git to gitfs in minion opts' fileserver_backend list
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: gibson.thuis
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[DEBUG   ] Configuration file path: /etc/salt/minion
[DEBUG   ] Grains refresh requested. Refreshing grains.
[DEBUG   ] Reading configuration from /etc/salt/minion
[DEBUG   ] Including configuration from '/etc/salt/minion.d/00_bootstrap.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/00_bootstrap.conf
[DEBUG   ] The functions from module 'core' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'disks' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'extra' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'lvm' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'mdadm' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'minion_process' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'opts' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'package' are being loaded by dir() on the loaded module
[DEBUG   ] Override  __utils__: <module 'salt.loaded.int.grains.zfs' from '/opt/saltstack/salt/lib/python3.10/site-packages/salt/grains/zfs.py'>
[DEBUG   ] The functions from module 'zfs' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'zfs' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded zfs.is_supported
[DEBUG   ] Determining pillar cache
[DEBUG   ] The functions from module 'roots' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded roots.envs
[DEBUG   ] pygit2 gitfs_provider enabled
[DEBUG   ] Created gitfs object with uninitialized remotes
[DEBUG   ] The functions from module 'gitfs' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded gitfs.envs
[DEBUG   ] The functions from module 's3fs' are being loaded by dir() on the loaded module
[DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
[DEBUG   ] Using selector: EpollSelector
[DEBUG   ] Created gitfs object for process 29047
[DEBUG   ] Updating roots fileserver cache
[DEBUG   ] Updating gitfs fileserver cache
[DEBUG   ] Re-using gitfs object for process 29047
[INFO    ] Wrote new gitfs remote map to /var/cache/salt/minion/gitfs/remote_map.txt
[DEBUG   ] The functions from module 'jinja' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] The functions from module 'yaml' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] compile template: /srv/pillar/top.sls
[DEBUG   ] Jinja search path: ['/srv/pillar']
[PROFILE ] Time (in seconds) to render '/srv/pillar/top.sls' using 'jinja' renderer: 0.002029895782470703
[PROFILE ] Time (in seconds) to render '/srv/pillar/top.sls' using 'yaml' renderer: 0.0005748271942138672
[DEBUG   ] The functions from module 'confirm_top' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded confirm_top.confirm_top
[DEBUG   ] The functions from module 'compound_match' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded compound_match.match
[DEBUG   ] compound_match: gibson.thuis ? gibson.thuis
[DEBUG   ] The functions from module 'glob_match' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded glob_match.match
[DEBUG   ] compound_match gibson.thuis ? "gibson.thuis" => "True"
[DEBUG   ] compile template: /srv/pillar/salt.sls
[DEBUG   ] Jinja search path: ['/srv/pillar']
[PROFILE ] Time (in seconds) to render '/srv/pillar/salt.sls' using 'jinja' renderer: 0.0006978511810302734
[PROFILE ] Time (in seconds) to render '/srv/pillar/salt.sls' using 'yaml' renderer: 0.00037741661071777344
[DEBUG   ] compile template: /srv/pillar/test.sls
[DEBUG   ] Jinja search path: ['/srv/pillar']
[PROFILE ] Time (in seconds) to render '/srv/pillar/test.sls' using 'jinja' renderer: 0.0006318092346191406
[PROFILE ] Time (in seconds) to render '/srv/pillar/test.sls' using 'yaml' renderer: 0.00023651123046875
[DEBUG   ] The functions from module 'jinja' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] The functions from module 'yaml' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] The functions from module 'state' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded state.apply
[DEBUG   ] The functions from module 'direct_call' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded direct_call.execute
[DEBUG   ] The functions from module 'config' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded config.option
[DEBUG   ] The functions from module 'saltutil' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded saltutil.is_running
[DEBUG   ] Override  __grains__: <module 'salt.loaded.int.module.grains' from '/opt/saltstack/salt/lib/python3.10/site-packages/salt/modules/grains.py'>
[DEBUG   ] The functions from module 'grains' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded grains.get
[DEBUG   ] The functions from module 'roots' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded roots.envs
[DEBUG   ] pygit2 gitfs_provider enabled
[DEBUG   ] Created gitfs object with uninitialized remotes
[DEBUG   ] The functions from module 'gitfs' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded gitfs.envs
[DEBUG   ] The functions from module 's3fs' are being loaded by dir() on the loaded module
[DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
[DEBUG   ] Re-using gitfs object for process 29047
[DEBUG   ] Updating roots fileserver cache
[DEBUG   ] Updating gitfs fileserver cache
[DEBUG   ] Re-using gitfs object for process 29047
[INFO    ] Wrote new gitfs remote map to /var/cache/salt/minion/gitfs/remote_map.txt
[DEBUG   ] Gathering pillar data for state run
[DEBUG   ] Finished gathering pillar data for state run
[INFO    ] Loading fresh modules for state activity
[DEBUG   ] The functions from module 'jinja' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] The functions from module 'yaml' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] Re-using gitfs object for process 29047
[DEBUG   ] Re-using gitfs object for process 29047
[DEBUG   ] Re-using gitfs object for process 29047
[DEBUG   ] Could not find file 'salt://salt/pkgrepo.sls' in saltenv 'base'
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/pkgrepo/init.sls' to resolve 'salt://salt/pkgrepo/init.sls'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/pkgrepo/init.sls' to resolve 'salt://salt/pkgrepo/init.sls'
[DEBUG   ] compile template: /var/cache/salt/minion/files/base/salt/pkgrepo/init.sls
[DEBUG   ] Jinja search path: ['/var/cache/salt/minion/files/base']
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/map.jinja' to resolve 'salt://salt/map.jinja'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/map.jinja' to resolve 'salt://salt/map.jinja'
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/defaults.yaml' to resolve 'salt://salt/defaults.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/defaults.yaml' to resolve 'salt://salt/defaults.yaml'
[PROFILE ] Time (in seconds) to render import_yaml 'salt/defaults.yaml': 0.010213375091552734
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/osfamilymap.yaml' to resolve 'salt://salt/osfamilymap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/osfamilymap.yaml' to resolve 'salt://salt/osfamilymap.yaml'
[DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://salt/osfamilymap.yaml'
[DEBUG   ] No dest file found
[INFO    ] Fetching file from saltenv 'base', ** done ** 'salt/osfamilymap.yaml'
[DEBUG   ] The functions from module 'pillar' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded pillar.get
[DEBUG   ] Override  __grains__: <module 'salt.loaded.int.module.grains' from '/opt/saltstack/salt/lib/python3.10/site-packages/salt/modules/grains.py'>
[DEBUG   ] The functions from module 'grains' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded grains.get
[PROFILE ] Time (in seconds) to render import_yaml 'salt/osfamilymap.yaml': 0.03139519691467285
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/osmap.yaml' to resolve 'salt://salt/osmap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/osmap.yaml' to resolve 'salt://salt/osmap.yaml'
[PROFILE ] Time (in seconds) to render import_yaml 'salt/osmap.yaml': 0.0223543643951416
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/osfingermap.yaml' to resolve 'salt://salt/osfingermap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/osfingermap.yaml' to resolve 'salt://salt/osfingermap.yaml'
[PROFILE ] Time (in seconds) to render import_yaml 'salt/osfingermap.yaml': 0.010776758193969727
[DEBUG   ] The functions from module 'defaults' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded defaults.merge
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/salt/pkgrepo/init.sls' using 'jinja' renderer: 0.08909749984741211
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/salt/pkgrepo/init.sls' using 'yaml' renderer: 0.00029921531677246094
[DEBUG   ] Re-using gitfs object for process 29047
[DEBUG   ] Re-using gitfs object for process 29047
[DEBUG   ] Could not find file 'salt://salt/pkgrepo/debian.sls' in saltenv 'base'
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/pkgrepo/debian/init.sls' to resolve 'salt://salt/pkgrepo/debian/init.sls'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/pkgrepo/debian/init.sls' to resolve 'salt://salt/pkgrepo/debian/init.sls'
[DEBUG   ] compile template: /var/cache/salt/minion/files/base/salt/pkgrepo/debian/init.sls
[DEBUG   ] Jinja search path: ['/var/cache/salt/minion/files/base']
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/salt/pkgrepo/debian/init.sls' using 'jinja' renderer: 0.0006659030914306641
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/salt/pkgrepo/debian/init.sls' using 'yaml' renderer: 0.0003268718719482422
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/pkgrepo/debian/install.sls' to resolve 'salt://salt/pkgrepo/debian/install.sls'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/pkgrepo/debian/install.sls' to resolve 'salt://salt/pkgrepo/debian/install.sls'
[DEBUG   ] compile template: /var/cache/salt/minion/files/base/salt/pkgrepo/debian/install.sls
[DEBUG   ] Jinja search path: ['/var/cache/salt/minion/files/base']
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/map.jinja' to resolve 'salt://salt/map.jinja'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/map.jinja' to resolve 'salt://salt/map.jinja'
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/defaults.yaml' to resolve 'salt://salt/defaults.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/defaults.yaml' to resolve 'salt://salt/defaults.yaml'
[PROFILE ] Time (in seconds) to render import_yaml 'salt/defaults.yaml': 0.009938478469848633
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/osfamilymap.yaml' to resolve 'salt://salt/osfamilymap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/osfamilymap.yaml' to resolve 'salt://salt/osfamilymap.yaml'
[PROFILE ] Time (in seconds) to render import_yaml 'salt/osfamilymap.yaml': 0.0281369686126709
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/osmap.yaml' to resolve 'salt://salt/osmap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/osmap.yaml' to resolve 'salt://salt/osmap.yaml'
[PROFILE ] Time (in seconds) to render import_yaml 'salt/osmap.yaml': 0.022192955017089844
[DEBUG   ] In saltenv 'base', looking at rel_path 'salt/osfingermap.yaml' to resolve 'salt://salt/osfingermap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/salt/osfingermap.yaml' to resolve 'salt://salt/osfingermap.yaml'
[PROFILE ] Time (in seconds) to render import_yaml 'salt/osfingermap.yaml': 0.010763883590698242
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/salt/pkgrepo/debian/install.sls' using 'jinja' renderer: 0.08374810218811035
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/salt/pkgrepo/debian/install.sls' using 'yaml' renderer: 0.003131389617919922
[DEBUG   ] The functions from module 'config' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded config.option
[DEBUG   ] The functions from module 'pkg' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded pkg.mod_repo
[DEBUG   ] The functions from module 'pkgrepo' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded pkgrepo.managed
[DEBUG   ] The functions from module 'file' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded file.managed
[DEBUG   ] The functions from module 'pkg' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded pkg.installed
[DEBUG   ] The functions from module 'lowpkg' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'kernelpkg' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pkg_resource' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'aliases' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'alternatives' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'archive' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'artifactory' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'baredoc' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'beacons' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'bigip' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'btrfs' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'path' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded path.which
[DEBUG   ] The functions from module 'chroot' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'cloud' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'cmd' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'composer' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'consul' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'container_resource' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'cp' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'cpan' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'cron' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'cryptdev' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'data' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'debconf' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'ip' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'devinfo' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'devmap' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'dig' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'disk' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'django' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'dnsmasq' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'dnsutil' are being loaded by dir() on the loaded module
[DEBUG   ] Override  __salt__: <module 'salt.loaded.int.module.dracr' from '/opt/saltstack/salt/lib/python3.10/site-packages/salt/modules/dracr.py'>
[DEBUG   ] The functions from module 'drbd' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'environ' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'ethtool' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'event' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'extfs' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'file' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'freezer' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'gem' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'genesis' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'git' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'glassfish' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'google_chat' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'gpg' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'grafana4' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'group' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'hashutil' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'helm' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'highstate_doc' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'hosts' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'http' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'aggregation' are being loaded from the provided __all__ attribute
[DEBUG   ] The functions from module 'args' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'asynchronous' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'atomicfile' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'aws' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'beacons' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'boto_elb_tag' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'cache' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'channel' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'cloud' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'color' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'compat' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'configcomparer' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'configparser' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'context' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'crypt' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'ctx' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'data' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'dateutils' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'debug' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'decorators' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'dictdiffer' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'dicttrim' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'dictupdate' are being loaded by dir() on the loaded module
[DEBUG   ] Override  __salt__: <module 'salt.loaded.int.utils.dns' from '/opt/saltstack/salt/lib/python3.10/site-packages/salt/utils/dns.py'>
[DEBUG   ] The functions from module 'dns' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'doc' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'entrypoints' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'environment' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'error' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'etcd_util' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'event' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'extend' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'extmods' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'filebuffer' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'files' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'find' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'fsutils' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'functools' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'gitfs' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'github' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'gzip_util' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'hashutils' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'http' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'iam' are being loaded by dir() on the loaded module
[DEBUG   ] Override  __salt__: <module 'salt.loaded.int.utils.icinga2' from '/opt/saltstack/salt/lib/python3.10/site-packages/salt/utils/icinga2.py'>
[DEBUG   ] The functions from module 'icinga2' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'immutabletypes' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'itertools' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'jid' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'jinja' are being loaded from the provided __all__ attribute
[DEBUG   ] The functions from module 'job' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'json' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'kickstart' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'kinds' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'lazy' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'listdiffer' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'locales' are being loaded by dir() on the loaded module
[DEBUG   ] Override  __salt__: <module 'salt.loaded.int.utils.mac_utils' from '/opt/saltstack/salt/lib/python3.10/site-packages/salt/utils/mac_utils.py'>
[DEBUG   ] The functions from module 'mako' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'master' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'mattermost' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'migrations' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'mine' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'minion' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'minions' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'mount' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'msgpack' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'namecheap' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'napalm' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'nb_popen' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'network' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'nxos' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'nxos_api' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'odict' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'openstack' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'oset' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'package' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pagerduty' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'parsers' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pkg' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'platform' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'powershell' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'preseed' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'process' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'profile' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'proxy' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'psutil_compat' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pushover' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pycrypto' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pydsl' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pyobjects' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'reactor' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'reclass' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'roster_matcher' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'rsax931' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 's3' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'saltclass' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'sanitizers' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'schedule' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'schema' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'sdb' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'slack' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'smb' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'smtp' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'ssdp' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'ssh' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'state' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'stringio' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'stringutils' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'systemd' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'templates' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'textformat' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'thin' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'timed_subprocess' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'timeout' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'timeutil' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'url' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'user' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'validate' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'value' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'vault' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'verify' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'versions' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'virt' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'virtualbox' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'vt' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'vt_helper' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'x509' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'xdg' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'xmlutil' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'yaml' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'yamldumper' are being loaded from the provided __all__ attribute
[DEBUG   ] The functions from module 'yamlencoding' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'yamllint' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'yamlloader' are being loaded from the provided __all__ attribute
[DEBUG   ] The functions from module 'yamlloader_old' are being loaded from the provided __all__ attribute
[DEBUG   ] The functions from module 'yast' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'zeromq' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'zfs' are being loaded by dir() on the loaded module
[DEBUG   ] Could not LazyLoad idem.hub: 'idem' __virtual__ returned False: No module named 'pop'
[DEBUG   ] The functions from module 'incron' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'ini' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'inspectlib' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'inspector' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'introspect' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'iosconfig' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'iwtools' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'jboss7' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'jboss7_cli' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'jinja' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'k8s' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'key' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'keyboard' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'kmod' are being loaded by dir() on the loaded module
[DEBUG   ] Override  __salt__: <module 'salt.loaded.int.module.kubeadm' from '/opt/saltstack/salt/lib/python3.10/site-packages/salt/modules/kubeadm.py'>
[DEBUG   ] The functions from module 'kubeadm' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'shadow' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'sysctl' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'locale' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'locate' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'log' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'logrotate' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'mandrill' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'match' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'mattermost' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'mine' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'minion' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'random' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'modjk' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'mount' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'msteams' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'nagios_rpc' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'namecheap_domains' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'namecheap_domains_dns' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'namecheap_domains_ns' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'namecheap_ssl' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'namecheap_users' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'network' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'nexus' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'nftables' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'nova' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'nspawn' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'nxos' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'nxos_api' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'nxos' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'openscap' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'openstack_config' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'opsgenie' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'out' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pagerduty' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pagerduty_util' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pam' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'parallels' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'peeringdb' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pip' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'ps' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'publish' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pushover' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'pyenv' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'random_org' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'rbenv' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'rest_sample_utils' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'restartcheck' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'ret' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'rvm' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 's3' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 's6' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'salt_proxy' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'salt_version' are being loaded by dir() on the loaded module
[DEBUG   ] Override  __context__: <module 'salt.loaded.int.module.saltcheck' from '/opt/saltstack/salt/lib/python3.10/site-packages/salt/modules/saltcheck.py'>
[DEBUG   ] The functions from module 'saltcheck' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'saltutil' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'schedule' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'scsi' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'sdb' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'seed' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'serverdensity_device' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'slack' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'slsutil' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'smbios' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'smtp' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'solrcloud' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'sqlite3' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'ssh' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'state' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'status' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'statuspage' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'supervisord' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'sysfs' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'syslog_ng' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'sys' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'system' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'service' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'telegram' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'telemetry' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'temp' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'test' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'timezone' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'tls' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'travisci' are being loaded by dir() on the loaded module
[DEBUG   ] Override  __salt__: <module 'salt.loaded.int.module.udev' from '/opt/saltstack/salt/lib/python3.10/site-packages/salt/modules/udev.py'>
[DEBUG   ] The functions from module 'udev' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'uptime' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'user' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'vault' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'vbox_guest' are being loaded by dir() on the loaded module
[DEBUG   ] Override  __pillar__: <module 'salt.loaded.int.module.virtualenv_mod' from '/opt/saltstack/salt/lib/python3.10/site-packages/salt/modules/virtualenv_mod.py'>
[DEBUG   ] The functions from module 'virtualenv' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'vsphere' are being loaded by dir() on the loaded module
[DEBUG   ] DSC: Only available on Windows systems
[DEBUG   ] Module PSGet: Only available on Windows systems
[DEBUG   ] Shortcut module only available on Windows systems
[DEBUG   ] The functions from module 'xfs' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'xml' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'zabbix' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'buildout' are being loaded by dir() on the loaded module
[DEBUG   ] The functions from module 'zenoss' are being loaded by dir() on the loaded module
[DEBUG   ] Could not LazyLoad pkg.ex_mod_init: 'pkg.ex_mod_init' is not available.
[INFO    ] Running state [gnupg] at time 15:15:01.837913
[INFO    ] Executing state pkg.installed for [gnupg]
[DEBUG   ] Could not LazyLoad pkg.resolve_capabilities: 'pkg.resolve_capabilities' is not available.
[INFO    ] Executing command dpkg-query in directory '/root'
[INFO    ] All specified packages are already installed
[INFO    ] Completed state [gnupg] at time 15:15:01.857076 (duration_in_ms=19.163)
[INFO    ] Running state [/usr/share/keyrings/SALT-PROJECT-GPG-PUBKEY-2023.gpg] at time 15:15:01.857252
[INFO    ] Executing state file.managed for [/usr/share/keyrings/SALT-PROJECT-GPG-PUBKEY-2023.gpg]
[INFO    ] File /usr/share/keyrings/SALT-PROJECT-GPG-PUBKEY-2023.gpg is in the correct state
[INFO    ] Completed state [/usr/share/keyrings/SALT-PROJECT-GPG-PUBKEY-2023.gpg] at time 15:15:01.859170 (duration_in_ms=1.918)
[INFO    ] Running state [/etc/apt/sources.list.d/saltstack.list] at time 15:15:01.859310
[INFO    ] Executing state file.absent for [/etc/apt/sources.list.d/saltstack.list]
[INFO    ] File /etc/apt/sources.list.d/saltstack.list is not present
[INFO    ] Completed state [/etc/apt/sources.list.d/saltstack.list] at time 15:15:01.859898 (duration_in_ms=0.587)
[INFO    ] Running state [deb [signed-by=/usr/share/keyrings/SALT-PROJECT-GPG-PUBKEY-2023.gpg arch=amd64] https://repo.saltproject.io/salt/py3/debian/12/amd64/latest bookworm main] at time 15:15:01.860056
[INFO    ] Executing state pkgrepo.managed for [deb [signed-by=/usr/share/keyrings/SALT-PROJECT-GPG-PUBKEY-2023.gpg arch=amd64] https://repo.saltproject.io/salt/py3/debian/12/amd64/latest bookworm main]
[INFO    ] Executing command apt-get in directory '/root'
[INFO    ] {'repo': 'deb [signed-by=/usr/share/keyrings/SALT-PROJECT-GPG-PUBKEY-2023.gpg arch=amd64] https://repo.saltproject.io/salt/py3/debian/12/amd64/latest bookworm main'}
[INFO    ] Completed state [deb [signed-by=/usr/share/keyrings/SALT-PROJECT-GPG-PUBKEY-2023.gpg arch=amd64] https://repo.saltproject.io/salt/py3/debian/12/amd64/latest bookworm main] at time 15:15:03.531164 (duration_in_ms=1671.108)
[DEBUG   ] File /var/cache/salt/minion/accumulator/140449678530912 does not exist, no need to cleanup
[DEBUG   ] The functions from module 'state' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded state.check_result
[DEBUG   ] The functions from module 'highstate' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded highstate.output
[DEBUG   ] The functions from module 'nested' are being loaded by dir() on the loaded module
[DEBUG   ] LazyLoaded nested.output
local:
  Name: gnupg - Function: pkg.installed - Result: Clean - Started: 15:15:01.837913 - Duration: 19.163 ms
  Name: /usr/share/keyrings/SALT-PROJECT-GPG-PUBKEY-2023.gpg - Function: file.managed - Result: Clean - Started: 15:15:01.857252 - Duration: 1.918 ms
  Name: /etc/apt/sources.list.d/saltstack.list - Function: file.absent - Result: Clean - Started: 15:15:01.859311 - Duration: 0.587 ms
----------
          ID: salt-pkgrepo-install-saltstack-debian
    Function: pkgrepo.managed
        Name: deb [signed-by=/usr/share/keyrings/SALT-PROJECT-GPG-PUBKEY-2023.gpg arch=amd64] https://repo.saltproject.io/salt/py3/debian/12/amd64/latest bookworm main
      Result: True
     Comment: Configured package repo 'deb [signed-by=/usr/share/keyrings/SALT-PROJECT-GPG-PUBKEY-2023.gpg arch=amd64] https://repo.saltproject.io/salt/py3/debian/12/amd64/latest bookworm main'
     Started: 15:15:01.860056
    Duration: 1671.108 ms
     Changes:
              ----------
              repo:
                  deb [signed-by=/usr/share/keyrings/SALT-PROJECT-GPG-PUBKEY-2023.gpg arch=amd64] https://repo.saltproject.io/salt/py3/debian/12/amd64/latest bookworm main

Summary for local
------------
Succeeded: 4 (changed=1)
Failed:    0
------------
Total states run:     4
Total run time:   1.693 s
```


### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


