### PR TITLE
feat(config): support emptying config

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -10,8 +10,14 @@ salt:
   # This state will remove "/etc/salt/minion" when you set this to true.
   minion_remove_config: true
 
+  # /etc/salt/minion will be emptied if you set this to true.
+  minion_empty_config: true
+
   # This state will remove "/etc/salt/master" when you set this to true.
   master_remove_config: true
+
+  # /etc/salt/master will be emptied if you set this to true.
+  master_empty_config: true
 
   # Set this to 'py3' to install the Python 3 packages.
   # The default varies between OS versions.

--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -16,7 +16,9 @@ salt:
   config_path: /etc/salt
 
   minion_remove_config: false
+  minion_empty_config: false
   master_remove_config: false
+  master_empty_config: false
   minion_config_use_TOFS: false
   master_config_use_TOFS: false
 

--- a/salt/master.sls
+++ b/salt/master.sls
@@ -72,6 +72,12 @@ remove-default-master-conf-file:
     - name: {{ salt_settings.config_path }}/master
     - watch_in:
       - service: salt-master
+    {% elif salt_settings.master_empty_config %}
+empty-default-master-conf-file:
+  file.managed:
+    - name: {{ salt_settings.config_path }}/master
+    - contents: |
+        # Configuration is managed by Salt
     {% endif %}
 
 # clean up old _defaults.conf file if they have it around

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -181,6 +181,12 @@ salt-minion-beacon-inotify:
 remove-default-minion-conf-file:
   file.absent:
     - name: {{ salt_settings.config_path }}/minion
+    {% elif salt_settings.minion_empty_config %}
+empty-default-minion-conf-file:
+  file.managed:
+    - name: {{ salt_settings.config_path }}/master
+    - contents: |
+        # Configuration is managed by Salt
     {% endif %}
 
 # clean up old _defaults.conf file if they have it around


### PR DESCRIPTION
The removal option is not suitable for systems where Salt is installed from distribution packages which place back a default configuration. Allow emptying the file instead of removing it, to benefit from removing any undesired, unmanaged, configuration changes in it, whilst not causing ping-pong between Salt and package updates.

<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->



### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

Reference pillar.example.

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


