### PR TITLE
fix: Add support for returner config block in the Returner settings section

### DIFF
--- a/salt/files/master.d/f_defaults.conf
+++ b/salt/files/master.d/f_defaults.conf
@@ -1743,7 +1743,22 @@ win_gitrepos:
 # Which returner(s) will be used for minion's result:
 #return: mysql
 {{ get_config('return', '')}}
-
+{%- if 'returner_config' in cfg_master %}
+  {%- do default_keys.append('returner_config') %}
+  {%- for key, value in cfg_master['returner_config'].items() %}
+{{ key }}: {{ value }}
+  {%- endfor %}
+{%- elif 'returner_config' in cfg_salt %}
+  {%- for key, value in cfg_salt['returner_config'].items() %}
+{{ key }}: {{ value }}
+  {%- endfor %}
+{%- else %}
+# mysql.host: 'salt'
+# mysql.user: 'salt'
+# mysql.pass: 'salt'
+# mysql.db: 'salt'
+# mysql.port: 3306
+{%- endif %}
 
 ######    Miscellaneous  settings     ######
 ############################################


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->


### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

This PR adds support for defining a pilar as `salt.master.returner_config` to allow to customize the Returner configuration, per [documentation](https://docs.saltproject.io/en/3006/ref/returners/index.html#event-returners)

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

1. [Optional] Define your secrets in an Env Var that is being loaded by the service

```bash
$ sudo cat /etc/systemd/system/salt-master.service.d/override.conf | grep -E "^\[Service\]|^EnvironmentFile"
[Service]
EnvironmentFile=-/etc/salt/environment.env
```

2. [Optional] Define the env var

```bash
$ cat /etc/salt/environment.env | sed -E "s|=.*|=<redacted>|g" 
SALT_RETURNER_POSTGRES_HOST=<redacted>
SALT_RETURNER_POSTGRES_PASSWD=<redacted>
```

3. Define the `returner_config` block in the pillars:

```
{% set returner_postgres_host = salt['environ.get']('SALT_RETURNER_POSTGRES_HOST', 'undefined') %}
{% set returner_postgres_passwd = salt['environ.get']('SALT_RETURNER_POSTGRES_PASSWD', 'undefined') %}

salt:
  master:
    returner_config:
      master_job_cache: postgres
      event_return: postgres
      returner.postgres.host: {{ returner_postgres_host }}
      returner.postgres.db: "salt"
      returner.postgres.user: "salt"
      returner.postgres.passwd: {{ returner_postgres_passwd }}
      returner.postgres.port: 5432
 ```

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->


### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->

Please let me know if I need to change other files or documentation.
