### PR TITLE
Fix -onlyif: condition

### DIFF
--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -40,7 +40,9 @@ download-salt-minion:
 
 salt-minion-macos:
   file.managed:
-    - onlyif: {{ grains.os == 'MacOS' }}
+    - onlyif:
+      - fun: match.grain
+        tgt: 'os:MacOS'
     - name: /Library/LaunchDaemons/com.saltstack.salt.minion.plist
     - source: https://raw.githubusercontent.com/saltstack/salt/master/pkg/macos/scripts/com.saltstack.salt.master.plist
     - source_hash: {{ salt_settings.salt_minion_macos_plist_hash }}


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

A very small fix. I ran into it by searching through our own code-bases after discovering a common error in Salt code.

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Replace the defective line `- onlyif: {{ grains.os == 'MacOS' }}`.

Jinja will generate either `True` or `False` with that condition. `- onlyif:` will attempt to execute this locally on the shell. Unless `True` exists as an application that can be called in the shell this line will result in the state not getting executed.

I must say, I have seen code like this before. I have written code like this, and recently an AI model suggested code like this. It makes me wonder whether this ever worked by accident. I imagine that if the Jinja templating returned `true` and `false` in lower case in the past this code might very well have worked on most Unix systems.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

I do not have a MacOS system, so I cannot test this exact condition. For all I know there exists a `True` command in the MacOS shell and this code original code functions correctly.

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->

I was grepping for this exact kind of mistake that seemed to be somewhat common and came across this instance of the issue.
