### PR TITLE
fix(minion): correct master_failback config option name

### DIFF
--- a/salt/files/minion.d/f_defaults.conf
+++ b/salt/files/minion.d/f_defaults.conf
@@ -100,12 +100,12 @@ proxy_password: {{ cfg_minion['proxy_password'] }}
 # If the minion is in multi-master mode and the master_type configuration option
 # is set to "failover", this setting can be set to "True" to force the minion
 # to fail back to the first master in the list if the first master is back online.
-{{ get_config('master_fallback', 'False') }}
+{{ get_config('master_failback', 'False') }}
 
 # If the minion is in multi-master mode, the "master_type" configuration is set to
 # "failover", and the "master_failback" option is enabled, the master failback
 # interval can be set to ping the top master with this interval, in seconds.
-{{ get_config('master_fallback_interval', '0') }}
+{{ get_config('master_failback_interval', '0') }}
 
 # Set whether the minion should connect to the master via IPv6:
 {{ get_config('ipv6', 'False') }}


### PR DESCRIPTION
`salt/files/minion.d/f_defaults.conf` renders `master_fallback` /
`master_fallback_interval`, but Salt's options are `master_failback` /
`master_failback_interval`. Easy typo to miss — the embedded word should be
**`fail`**, not **`fall`**:

    master_fallback   <- template renders this (not a Salt option)
    master_failback   <- Salt's actual option
             ^

With no generic passthrough (only keys with an explicit `get_config` call are
rendered), setting `master_failback` in pillar is silently dropped today; the
correct spelling already appears in this file's comments.

Verify against Salt's source (VALID_OPTS / DEFAULT_MINION_OPTS):
https://github.com/saltstack/salt/blob/v3008.1/salt/config/__init__.py#L151-L154
https://github.com/saltstack/salt/blob/v3008.1/salt/config/__init__.py#L1132-L1133

Typo present since 2017 (edce95f).

Co-authored-by: Claude <noreply@anthropic.com>
