### PR TITLE
test: fix failing kitchen suites by pinning salt to the image version

### DIFF
--- a/test/integration/default/controls/_mapdata.rb
+++ b/test/integration/default/controls/_mapdata.rb
@@ -24,6 +24,8 @@ control 'salt._mapdata' do
   # Load the mapdata from profile, into a YAML structure
   # https://docs.chef.io/inspec/profiles/#profile-files
   mapdata_file_yaml = YAML.load(inspec.profile.file(mapdata_file_path))
+  # salt_settings.version is pinned to the kitchen image's salt, so drop it
+  mapdata_file_yaml.dig('values', 'salt_settings')&.delete('version')
   # Dump the YAML back into a string for comparison
   mapdata_file_dump = YAML.dump(mapdata_file_yaml)
 
@@ -36,6 +38,8 @@ control 'salt._mapdata' do
   # Load the output into a YAML structure using InSpec's `yaml` resource
   # https://github.com/inspec/inspec/blob/49b7d10/lib/inspec/resources/yaml.rb#L29
   output_file_yaml = yaml(output_file_path).params
+  # drop the image-pinned salt_settings.version here too
+  output_file_yaml.dig('values', 'salt_settings')&.delete('version')
   # Dump the YAML back into a string for comparison
   output_file_dump = YAML.dump(output_file_yaml)
 

--- a/test/salt/pillar/salt.sls
+++ b/test/salt/pillar/salt.sls
@@ -3,6 +3,11 @@
 ---
 salt:
   py_ver: 'py3'
+  # Pin to the salt version baked into the kitchen image so salt.minion/salt.master
+  # don't upgrade it to the repo's "latest" in place mid-converge — swapping the
+  # running onedir breaks the post-install module refresh, which raises:
+  #   ModuleNotFoundError: spec not found for the module 'site'
+  version: "{{ salt['grains.get']('saltversion') }}"
   # Override used for FreeBSD minion service
   retry_options:
     attempts: 5


### PR DESCRIPTION
I opened #590 to fix a one-line typo, but its GitLab CI jobs failed — and
other PRs (e.g. #589) fail with the same error. So the kitchen suites seem to
be failing independently of any change; this PR is an attempt to fix that.

The `*-3006*` / `*-3007*` suites die on every platform while applying the states:

```
'salt' changed from '3006.17-0' to '3008.1-0'
[ERROR ] ModuleNotFoundError: spec not found for the module 'site'
>>>>>> Converge failed on <default-oraclelinux-9-3006-17>
```

Those images ship salt 3006.17 / 3007.9, but `salt.pkgrepo` adds the
`salt-repo-latest` repo (currently 3008.1) and the unpinned `pkg.installed`
upgrades salt **in place** — swapping the onedir under the running `salt-call`,
which breaks the post-install module refresh.

The per-version pins in `test/salt/pillar/` only cover 3002/3003/3004 and set
`salt:release`, which no state reads anymore — so the current images get no
pin. This pins `salt:version` to the image's running salt (`grains.saltversion`)
instead, so the formula keeps it rather than upgrading.

I couldn't run kitchen locally, so this leans on the PR's CI matrix to validate.
(The stale `v3002/3/4-py3.sls` `release` pins are dead now and could be dropped
in a follow-up.)

Disclosure: prepared with the assistance of Claude (an LLM).
